### PR TITLE
Use printf escape tokens for ESC and BEL

### DIFF
--- a/functions/base16-3024.fish
+++ b/functions/base16-3024.fish
@@ -31,22 +31,22 @@ function base16-3024 -d "3024"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-apathy.fish
+++ b/functions/base16-apathy.fish
@@ -31,22 +31,22 @@ function base16-apathy -d "Apathy"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-ashes.fish
+++ b/functions/base16-ashes.fish
@@ -31,22 +31,22 @@ function base16-ashes -d "Ashes"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-cave-light.fish
+++ b/functions/base16-atelier-cave-light.fish
@@ -31,22 +31,22 @@ function base16-atelier-cave-light -d "Atelier Cave Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-cave.fish
+++ b/functions/base16-atelier-cave.fish
@@ -31,22 +31,22 @@ function base16-atelier-cave -d "Atelier Cave"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-dune-light.fish
+++ b/functions/base16-atelier-dune-light.fish
@@ -31,22 +31,22 @@ function base16-atelier-dune-light -d "Atelier Dune Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-dune.fish
+++ b/functions/base16-atelier-dune.fish
@@ -31,22 +31,22 @@ function base16-atelier-dune -d "Atelier Dune"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-estuary-light.fish
+++ b/functions/base16-atelier-estuary-light.fish
@@ -31,22 +31,22 @@ function base16-atelier-estuary-light -d "Atelier Estuary Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-estuary.fish
+++ b/functions/base16-atelier-estuary.fish
@@ -31,22 +31,22 @@ function base16-atelier-estuary -d "Atelier Estuary"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-forest-light.fish
+++ b/functions/base16-atelier-forest-light.fish
@@ -31,22 +31,22 @@ function base16-atelier-forest-light -d "Atelier Forest Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-forest.fish
+++ b/functions/base16-atelier-forest.fish
@@ -31,22 +31,22 @@ function base16-atelier-forest -d "Atelier Forest"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-heath-light.fish
+++ b/functions/base16-atelier-heath-light.fish
@@ -31,22 +31,22 @@ function base16-atelier-heath-light -d "Atelier Heath Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-heath.fish
+++ b/functions/base16-atelier-heath.fish
@@ -31,22 +31,22 @@ function base16-atelier-heath -d "Atelier Heath"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-lakeside-light.fish
+++ b/functions/base16-atelier-lakeside-light.fish
@@ -31,22 +31,22 @@ function base16-atelier-lakeside-light -d "Atelier Lakeside Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-lakeside.fish
+++ b/functions/base16-atelier-lakeside.fish
@@ -31,22 +31,22 @@ function base16-atelier-lakeside -d "Atelier Lakeside"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-plateau-light.fish
+++ b/functions/base16-atelier-plateau-light.fish
@@ -31,22 +31,22 @@ function base16-atelier-plateau-light -d "Atelier Plateau Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-plateau.fish
+++ b/functions/base16-atelier-plateau.fish
@@ -31,22 +31,22 @@ function base16-atelier-plateau -d "Atelier Plateau"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-savanna-light.fish
+++ b/functions/base16-atelier-savanna-light.fish
@@ -31,22 +31,22 @@ function base16-atelier-savanna-light -d "Atelier Savanna Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-savanna.fish
+++ b/functions/base16-atelier-savanna.fish
@@ -31,22 +31,22 @@ function base16-atelier-savanna -d "Atelier Savanna"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-seaside-light.fish
+++ b/functions/base16-atelier-seaside-light.fish
@@ -31,22 +31,22 @@ function base16-atelier-seaside-light -d "Atelier Seaside Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-seaside.fish
+++ b/functions/base16-atelier-seaside.fish
@@ -31,22 +31,22 @@ function base16-atelier-seaside -d "Atelier Seaside"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-sulphurpool-light.fish
+++ b/functions/base16-atelier-sulphurpool-light.fish
@@ -31,22 +31,22 @@ function base16-atelier-sulphurpool-light -d "Atelier Sulphurpool Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atelier-sulphurpool.fish
+++ b/functions/base16-atelier-sulphurpool.fish
@@ -31,22 +31,22 @@ function base16-atelier-sulphurpool -d "Atelier Sulphurpool"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-atlas.fish
+++ b/functions/base16-atlas.fish
@@ -31,22 +31,22 @@ function base16-atlas -d "Atlas"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-bespin.fish
+++ b/functions/base16-bespin.fish
@@ -31,22 +31,22 @@ function base16-bespin -d "Bespin"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-black-metal-bathory.fish
+++ b/functions/base16-black-metal-bathory.fish
@@ -31,22 +31,22 @@ function base16-black-metal-bathory -d "Black Metal (Bathory)"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-black-metal-burzum.fish
+++ b/functions/base16-black-metal-burzum.fish
@@ -31,22 +31,22 @@ function base16-black-metal-burzum -d "Black Metal (Burzum)"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-black-metal-dark-funeral.fish
+++ b/functions/base16-black-metal-dark-funeral.fish
@@ -31,22 +31,22 @@ function base16-black-metal-dark-funeral -d "Black Metal (Dark Funeral)"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-black-metal-gorgoroth.fish
+++ b/functions/base16-black-metal-gorgoroth.fish
@@ -31,22 +31,22 @@ function base16-black-metal-gorgoroth -d "Black Metal (Gorgoroth)"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-black-metal-immortal.fish
+++ b/functions/base16-black-metal-immortal.fish
@@ -31,22 +31,22 @@ function base16-black-metal-immortal -d "Black Metal (Immortal)"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-black-metal-khold.fish
+++ b/functions/base16-black-metal-khold.fish
@@ -31,22 +31,22 @@ function base16-black-metal-khold -d "Black Metal (Khold)"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-black-metal-marduk.fish
+++ b/functions/base16-black-metal-marduk.fish
@@ -31,22 +31,22 @@ function base16-black-metal-marduk -d "Black Metal (Marduk)"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-black-metal-mayhem.fish
+++ b/functions/base16-black-metal-mayhem.fish
@@ -31,22 +31,22 @@ function base16-black-metal-mayhem -d "Black Metal (Mayhem)"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-black-metal-nile.fish
+++ b/functions/base16-black-metal-nile.fish
@@ -31,22 +31,22 @@ function base16-black-metal-nile -d "Black Metal (Nile)"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-black-metal-venom.fish
+++ b/functions/base16-black-metal-venom.fish
@@ -31,22 +31,22 @@ function base16-black-metal-venom -d "Black Metal (Venom)"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-black-metal.fish
+++ b/functions/base16-black-metal.fish
@@ -31,22 +31,22 @@ function base16-black-metal -d "Black Metal"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-brewer.fish
+++ b/functions/base16-brewer.fish
@@ -31,22 +31,22 @@ function base16-brewer -d "Brewer"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-bright.fish
+++ b/functions/base16-bright.fish
@@ -31,22 +31,22 @@ function base16-bright -d "Bright"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-brogrammer.fish
+++ b/functions/base16-brogrammer.fish
@@ -31,22 +31,22 @@ function base16-brogrammer -d "Brogrammer"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-brushtrees-dark.fish
+++ b/functions/base16-brushtrees-dark.fish
@@ -31,22 +31,22 @@ function base16-brushtrees-dark -d "Brush Trees Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-brushtrees.fish
+++ b/functions/base16-brushtrees.fish
@@ -31,22 +31,22 @@ function base16-brushtrees -d "Brush Trees"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-chalk.fish
+++ b/functions/base16-chalk.fish
@@ -31,22 +31,22 @@ function base16-chalk -d "Chalk"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-circus.fish
+++ b/functions/base16-circus.fish
@@ -31,22 +31,22 @@ function base16-circus -d "Circus"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-classic-dark.fish
+++ b/functions/base16-classic-dark.fish
@@ -31,22 +31,22 @@ function base16-classic-dark -d "Classic Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-classic-light.fish
+++ b/functions/base16-classic-light.fish
@@ -31,22 +31,22 @@ function base16-classic-light -d "Classic Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-codeschool.fish
+++ b/functions/base16-codeschool.fish
@@ -31,22 +31,22 @@ function base16-codeschool -d "Codeschool"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-cupcake.fish
+++ b/functions/base16-cupcake.fish
@@ -31,22 +31,22 @@ function base16-cupcake -d "Cupcake"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-cupertino.fish
+++ b/functions/base16-cupertino.fish
@@ -31,22 +31,22 @@ function base16-cupertino -d "Cupertino"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-darktooth.fish
+++ b/functions/base16-darktooth.fish
@@ -31,22 +31,22 @@ function base16-darktooth -d "Darktooth"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-default-dark.fish
+++ b/functions/base16-default-dark.fish
@@ -31,22 +31,22 @@ function base16-default-dark -d "Default Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-default-light.fish
+++ b/functions/base16-default-light.fish
@@ -31,22 +31,22 @@ function base16-default-light -d "Default Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-dracula.fish
+++ b/functions/base16-dracula.fish
@@ -31,22 +31,22 @@ function base16-dracula -d "Dracula"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-eighties.fish
+++ b/functions/base16-eighties.fish
@@ -31,22 +31,22 @@ function base16-eighties -d "Eighties"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-embers.fish
+++ b/functions/base16-embers.fish
@@ -31,22 +31,22 @@ function base16-embers -d "Embers"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-flat.fish
+++ b/functions/base16-flat.fish
@@ -31,22 +31,22 @@ function base16-flat -d "Flat"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-framer.fish
+++ b/functions/base16-framer.fish
@@ -31,22 +31,22 @@ function base16-framer -d "Framer"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-fruit-soda.fish
+++ b/functions/base16-fruit-soda.fish
@@ -31,22 +31,22 @@ function base16-fruit-soda -d "Fruit Soda"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-github.fish
+++ b/functions/base16-github.fish
@@ -31,22 +31,22 @@ function base16-github -d "Github"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-google-dark.fish
+++ b/functions/base16-google-dark.fish
@@ -31,22 +31,22 @@ function base16-google-dark -d "Google Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-google-light.fish
+++ b/functions/base16-google-light.fish
@@ -31,22 +31,22 @@ function base16-google-light -d "Google Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-grayscale-dark.fish
+++ b/functions/base16-grayscale-dark.fish
@@ -31,22 +31,22 @@ function base16-grayscale-dark -d "Grayscale Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-grayscale-light.fish
+++ b/functions/base16-grayscale-light.fish
@@ -31,22 +31,22 @@ function base16-grayscale-light -d "Grayscale Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-greenscreen.fish
+++ b/functions/base16-greenscreen.fish
@@ -31,22 +31,22 @@ function base16-greenscreen -d "Green Screen"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-gruvbox-dark-hard.fish
+++ b/functions/base16-gruvbox-dark-hard.fish
@@ -31,22 +31,22 @@ function base16-gruvbox-dark-hard -d "Gruvbox dark, hard"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-gruvbox-dark-medium.fish
+++ b/functions/base16-gruvbox-dark-medium.fish
@@ -31,22 +31,22 @@ function base16-gruvbox-dark-medium -d "Gruvbox dark, medium"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-gruvbox-dark-pale.fish
+++ b/functions/base16-gruvbox-dark-pale.fish
@@ -31,22 +31,22 @@ function base16-gruvbox-dark-pale -d "Gruvbox dark, pale"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-gruvbox-dark-soft.fish
+++ b/functions/base16-gruvbox-dark-soft.fish
@@ -31,22 +31,22 @@ function base16-gruvbox-dark-soft -d "Gruvbox dark, soft"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-gruvbox-light-hard.fish
+++ b/functions/base16-gruvbox-light-hard.fish
@@ -31,22 +31,22 @@ function base16-gruvbox-light-hard -d "Gruvbox light, hard"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-gruvbox-light-medium.fish
+++ b/functions/base16-gruvbox-light-medium.fish
@@ -31,22 +31,22 @@ function base16-gruvbox-light-medium -d "Gruvbox light, medium"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-gruvbox-light-soft.fish
+++ b/functions/base16-gruvbox-light-soft.fish
@@ -31,22 +31,22 @@ function base16-gruvbox-light-soft -d "Gruvbox light, soft"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-harmonic-dark.fish
+++ b/functions/base16-harmonic-dark.fish
@@ -31,22 +31,22 @@ function base16-harmonic-dark -d "Harmonic16 Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-harmonic-light.fish
+++ b/functions/base16-harmonic-light.fish
@@ -31,22 +31,22 @@ function base16-harmonic-light -d "Harmonic16 Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-heetch-light.fish
+++ b/functions/base16-heetch-light.fish
@@ -31,22 +31,22 @@ function base16-heetch-light -d "Heetch Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-heetch.fish
+++ b/functions/base16-heetch.fish
@@ -31,22 +31,22 @@ function base16-heetch -d "Heetch Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-helios.fish
+++ b/functions/base16-helios.fish
@@ -31,22 +31,22 @@ function base16-helios -d "Helios"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-hopscotch.fish
+++ b/functions/base16-hopscotch.fish
@@ -31,22 +31,22 @@ function base16-hopscotch -d "Hopscotch"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-horizon-dark.fish
+++ b/functions/base16-horizon-dark.fish
@@ -31,22 +31,22 @@ function base16-horizon-dark -d "Horizon Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-horizon-light.fish
+++ b/functions/base16-horizon-light.fish
@@ -31,22 +31,22 @@ function base16-horizon-light -d "Horizon Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-horizon-terminal-dark.fish
+++ b/functions/base16-horizon-terminal-dark.fish
@@ -31,22 +31,22 @@ function base16-horizon-terminal-dark -d "Horizon Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-horizon-terminal-light.fish
+++ b/functions/base16-horizon-terminal-light.fish
@@ -31,22 +31,22 @@ function base16-horizon-terminal-light -d "Horizon Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-ia-dark.fish
+++ b/functions/base16-ia-dark.fish
@@ -31,22 +31,22 @@ function base16-ia-dark -d "iA Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-ia-light.fish
+++ b/functions/base16-ia-light.fish
@@ -31,22 +31,22 @@ function base16-ia-light -d "iA Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-icy.fish
+++ b/functions/base16-icy.fish
@@ -31,22 +31,22 @@ function base16-icy -d "Icy Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-irblack.fish
+++ b/functions/base16-irblack.fish
@@ -31,22 +31,22 @@ function base16-irblack -d "IR Black"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-isotope.fish
+++ b/functions/base16-isotope.fish
@@ -31,22 +31,22 @@ function base16-isotope -d "Isotope"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-macintosh.fish
+++ b/functions/base16-macintosh.fish
@@ -31,22 +31,22 @@ function base16-macintosh -d "Macintosh"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-marrakesh.fish
+++ b/functions/base16-marrakesh.fish
@@ -31,22 +31,22 @@ function base16-marrakesh -d "Marrakesh"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-materia.fish
+++ b/functions/base16-materia.fish
@@ -31,22 +31,22 @@ function base16-materia -d "Materia"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-material-darker.fish
+++ b/functions/base16-material-darker.fish
@@ -31,22 +31,22 @@ function base16-material-darker -d "Material Darker"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-material-lighter.fish
+++ b/functions/base16-material-lighter.fish
@@ -31,22 +31,22 @@ function base16-material-lighter -d "Material Lighter"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-material-palenight.fish
+++ b/functions/base16-material-palenight.fish
@@ -31,22 +31,22 @@ function base16-material-palenight -d "Material Palenight"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-material-vivid.fish
+++ b/functions/base16-material-vivid.fish
@@ -31,22 +31,22 @@ function base16-material-vivid -d "Material Vivid"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-material.fish
+++ b/functions/base16-material.fish
@@ -31,22 +31,22 @@ function base16-material -d "Material"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-mellow-purple.fish
+++ b/functions/base16-mellow-purple.fish
@@ -31,22 +31,22 @@ function base16-mellow-purple -d "Mellow Purple"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-mexico-light.fish
+++ b/functions/base16-mexico-light.fish
@@ -31,22 +31,22 @@ function base16-mexico-light -d "Mexico Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-mocha.fish
+++ b/functions/base16-mocha.fish
@@ -31,22 +31,22 @@ function base16-mocha -d "Mocha"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-monokai.fish
+++ b/functions/base16-monokai.fish
@@ -31,22 +31,22 @@ function base16-monokai -d "Monokai"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-nord.fish
+++ b/functions/base16-nord.fish
@@ -31,22 +31,22 @@ function base16-nord -d "Nord"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-ocean.fish
+++ b/functions/base16-ocean.fish
@@ -31,22 +31,22 @@ function base16-ocean -d "Ocean"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-oceanicnext.fish
+++ b/functions/base16-oceanicnext.fish
@@ -31,22 +31,22 @@ function base16-oceanicnext -d "OceanicNext"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-one-light.fish
+++ b/functions/base16-one-light.fish
@@ -31,22 +31,22 @@ function base16-one-light -d "One Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-onedark.fish
+++ b/functions/base16-onedark.fish
@@ -31,22 +31,22 @@ function base16-onedark -d "OneDark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-outrun-dark.fish
+++ b/functions/base16-outrun-dark.fish
@@ -31,22 +31,22 @@ function base16-outrun-dark -d "Outrun Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-papercolor-dark.fish
+++ b/functions/base16-papercolor-dark.fish
@@ -31,22 +31,22 @@ function base16-papercolor-dark -d "PaperColor Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-papercolor-light.fish
+++ b/functions/base16-papercolor-light.fish
@@ -31,22 +31,22 @@ function base16-papercolor-light -d "PaperColor Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-paraiso.fish
+++ b/functions/base16-paraiso.fish
@@ -31,22 +31,22 @@ function base16-paraiso -d "Paraiso"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-phd.fish
+++ b/functions/base16-phd.fish
@@ -31,22 +31,22 @@ function base16-phd -d "PhD"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-pico.fish
+++ b/functions/base16-pico.fish
@@ -31,22 +31,22 @@ function base16-pico -d "Pico"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-pop.fish
+++ b/functions/base16-pop.fish
@@ -31,22 +31,22 @@ function base16-pop -d "Pop"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-porple.fish
+++ b/functions/base16-porple.fish
@@ -31,22 +31,22 @@ function base16-porple -d "Porple"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-railscasts.fish
+++ b/functions/base16-railscasts.fish
@@ -31,22 +31,22 @@ function base16-railscasts -d "Railscasts"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-rebecca.fish
+++ b/functions/base16-rebecca.fish
@@ -31,22 +31,22 @@ function base16-rebecca -d "Rebecca"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-seti.fish
+++ b/functions/base16-seti.fish
@@ -31,22 +31,22 @@ function base16-seti -d "Seti UI"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-shapeshifter.fish
+++ b/functions/base16-shapeshifter.fish
@@ -31,22 +31,22 @@ function base16-shapeshifter -d "Shapeshifter"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-snazzy.fish
+++ b/functions/base16-snazzy.fish
@@ -31,22 +31,22 @@ function base16-snazzy -d "Snazzy"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-solarflare.fish
+++ b/functions/base16-solarflare.fish
@@ -31,22 +31,22 @@ function base16-solarflare -d "Solar Flare"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-solarized-dark.fish
+++ b/functions/base16-solarized-dark.fish
@@ -31,22 +31,22 @@ function base16-solarized-dark -d "Solarized Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-solarized-light.fish
+++ b/functions/base16-solarized-light.fish
@@ -31,22 +31,22 @@ function base16-solarized-light -d "Solarized Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-spacemacs.fish
+++ b/functions/base16-spacemacs.fish
@@ -31,22 +31,22 @@ function base16-spacemacs -d "Spacemacs"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-summerfruit-dark.fish
+++ b/functions/base16-summerfruit-dark.fish
@@ -31,22 +31,22 @@ function base16-summerfruit-dark -d "Summerfruit Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-summerfruit-light.fish
+++ b/functions/base16-summerfruit-light.fish
@@ -31,22 +31,22 @@ function base16-summerfruit-light -d "Summerfruit Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-synth-midnight-dark.fish
+++ b/functions/base16-synth-midnight-dark.fish
@@ -31,22 +31,22 @@ function base16-synth-midnight-dark -d "Synth Midnight Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-tomorrow-night-eighties.fish
+++ b/functions/base16-tomorrow-night-eighties.fish
@@ -31,22 +31,22 @@ function base16-tomorrow-night-eighties -d "Tomorrow Night"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-tomorrow-night.fish
+++ b/functions/base16-tomorrow-night.fish
@@ -31,22 +31,22 @@ function base16-tomorrow-night -d "Tomorrow Night"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-tomorrow.fish
+++ b/functions/base16-tomorrow.fish
@@ -31,22 +31,22 @@ function base16-tomorrow -d "Tomorrow"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-tube.fish
+++ b/functions/base16-tube.fish
@@ -31,22 +31,22 @@ function base16-tube -d "London Tube"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-twilight.fish
+++ b/functions/base16-twilight.fish
@@ -31,22 +31,22 @@ function base16-twilight -d "Twilight"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-unikitty-dark.fish
+++ b/functions/base16-unikitty-dark.fish
@@ -31,22 +31,22 @@ function base16-unikitty-dark -d "Unikitty Dark"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-unikitty-light.fish
+++ b/functions/base16-unikitty-light.fish
@@ -31,22 +31,22 @@ function base16-unikitty-light -d "Unikitty Light"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-woodland.fish
+++ b/functions/base16-woodland.fish
@@ -31,22 +31,22 @@ function base16-woodland -d "Woodland"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-xcode-dusk.fish
+++ b/functions/base16-xcode-dusk.fish
@@ -31,22 +31,22 @@ function base16-xcode-dusk -d "XCode Dusk"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/functions/base16-zenburn.fish
+++ b/functions/base16-zenburn.fish
@@ -31,22 +31,22 @@ function base16-zenburn -d "Zenburn"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -31,22 +31,22 @@ function base16-{{scheme-slug}} -d "{{scheme-name}}"
   if test -n "$TMUX"
     # Tell tmux to pass the escape sequences through
     # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
-    function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
-    function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
+    function put_template; printf '\ePtmux;\e\e]4;%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_var; printf '\ePtmux;\e\e]%d;rgb:%s\e\e\\\e\\' $argv; end;
+    function put_template_custom; printf '\ePtmux;\e\e]%s%s\e\e\\\e\\' $argv; end;
   else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
-    function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
-    function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
+    function put_template; printf '\eP\e]4;%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_var; printf '\eP\e]%d;rgb:%s\a\e\\' $argv; end;
+    function put_template_custom; printf '\eP\e]%s%s\a\e\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else
-    function put_template; printf '\033]4;%d;rgb:%s\033\\' $argv; end;
-    function put_template_var; printf '\033]%d;rgb:%s\033\\' $argv; end;
-    function put_template_custom; printf '\033]%s%s\033\\' $argv; end;
+    function put_template; printf '\e]4;%d;rgb:%s\e\\' $argv; end;
+    function put_template_var; printf '\e]%d;rgb:%s\e\\' $argv; end;
+    function put_template_custom; printf '\e]%s%s\e\\' $argv; end;
   end
 
   # 16 color space


### PR DESCRIPTION
Don't ask me why, but without using the `printf` shorthand for these escape sequences, I was getting all kinds of garbage text printed in each new window, among other rendering weirdness. In theory, there should be no difference between using these shorthand tokens and using the numeric literals, but this fixed the issue for me so... ¯\\\_(ツ)\_/¯

For reference, my versions (though I didn't test on others):
```
❯ fish --version ; tmux -V
fish, version 3.0.2
tmux 2.9a
```