### PR TITLE
Only evauate for login shells, fixing ProxyCommand issues

### DIFF
--- a/conf.d/base16.fish
+++ b/conf.d/base16.fish
@@ -1,3 +1,3 @@
-if test -n "$base16_theme"
+if test -n "$base16_theme" && status --is-login
   base16-$base16_theme
 end


### PR DESCRIPTION
Currently this breaks SSH using ProxyCommand in ~/.ssh/config

```
debug1: Local version string SSH-2.0-OpenSSH_7.9
debug1: ssh_exchange_identification: \033]4;0;rgb:18/18/18\033\\\033]4;1;rgb:ab/46/42\033\\\033]4;2;rgb:a1/b5/6c\033\\\033]4;3;rgb:f7/ca/88\033\\\033]4;4;rgb:7c/af/c2\033\\\033]4;5;rgb:ba/8b/af\033\\\033]4;6;rgb:86/c1/b9\033\\\033]4;7;rgb:d8/d8/d8\033\\\033]4;8;rgb:58/58/58\033\\\033]4;9;rgb:ab/46/42\033\\\033]4;10;rgb:a1/b5/6c\033\\\033]4;11;rgb:f7/ca/88\033\\\033]4;12;rgb:7c
debug1: ssh_exchange_identification: /af/c2\033\\\033]4;13;rgb:ba/8b/af\033\\\033]4;14;rgb:86/c1/b9\033\\\033]4;15;rgb:f8/f8/f8\033\\\033]4;16;rgb:dc/96/56\033\\\033]4;17;rgb:a1/69/46\033\\\033]4;18;rgb:28/28/28\033\\\033]4;19;rgb:38/38/38\033\\\033]4;20;rgb:b8/b8/b8\033\\\033]4;21;rgb:e8/e8/e8\033\\\033]Pgd8d8d8\033\\\033]Ph181818\033\\\033]Pid8d8d8\033\\\033]Pj383838\033\\\033]Pkd8d8d8
```

This fixes the issue by only running when in a login shell.

See:
- https://github.com/chriskempson/base16-shell/issues/42
- https://github.com/fish-shell/fish-shell/issues/2160