### PR TITLE
Fix for startup errors (line 43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Installation
 1. If you have [fisher](https://github.com/jorgebucaran/fisher),
 ```
-$ fisher add tomyun/base16-fish
+$ fisher install tomyun/base16-fish
 ```
 
 2. Run your choice of `base16-*` function

--- a/functions/base16-3024.fish
+++ b/functions/base16-3024.fish
@@ -40,7 +40,7 @@ function base16-3024 -d "3024"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-apathy.fish
+++ b/functions/base16-apathy.fish
@@ -40,7 +40,7 @@ function base16-apathy -d "Apathy"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-ashes.fish
+++ b/functions/base16-ashes.fish
@@ -40,7 +40,7 @@ function base16-ashes -d "Ashes"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-cave-light.fish
+++ b/functions/base16-atelier-cave-light.fish
@@ -40,7 +40,7 @@ function base16-atelier-cave-light -d "Atelier Cave Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-cave.fish
+++ b/functions/base16-atelier-cave.fish
@@ -40,7 +40,7 @@ function base16-atelier-cave -d "Atelier Cave"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-dune-light.fish
+++ b/functions/base16-atelier-dune-light.fish
@@ -40,7 +40,7 @@ function base16-atelier-dune-light -d "Atelier Dune Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-dune.fish
+++ b/functions/base16-atelier-dune.fish
@@ -40,7 +40,7 @@ function base16-atelier-dune -d "Atelier Dune"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-estuary-light.fish
+++ b/functions/base16-atelier-estuary-light.fish
@@ -40,7 +40,7 @@ function base16-atelier-estuary-light -d "Atelier Estuary Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-estuary.fish
+++ b/functions/base16-atelier-estuary.fish
@@ -40,7 +40,7 @@ function base16-atelier-estuary -d "Atelier Estuary"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-forest-light.fish
+++ b/functions/base16-atelier-forest-light.fish
@@ -40,7 +40,7 @@ function base16-atelier-forest-light -d "Atelier Forest Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-forest.fish
+++ b/functions/base16-atelier-forest.fish
@@ -40,7 +40,7 @@ function base16-atelier-forest -d "Atelier Forest"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-heath-light.fish
+++ b/functions/base16-atelier-heath-light.fish
@@ -40,7 +40,7 @@ function base16-atelier-heath-light -d "Atelier Heath Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-heath.fish
+++ b/functions/base16-atelier-heath.fish
@@ -40,7 +40,7 @@ function base16-atelier-heath -d "Atelier Heath"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-lakeside-light.fish
+++ b/functions/base16-atelier-lakeside-light.fish
@@ -40,7 +40,7 @@ function base16-atelier-lakeside-light -d "Atelier Lakeside Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-lakeside.fish
+++ b/functions/base16-atelier-lakeside.fish
@@ -40,7 +40,7 @@ function base16-atelier-lakeside -d "Atelier Lakeside"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-plateau-light.fish
+++ b/functions/base16-atelier-plateau-light.fish
@@ -40,7 +40,7 @@ function base16-atelier-plateau-light -d "Atelier Plateau Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-plateau.fish
+++ b/functions/base16-atelier-plateau.fish
@@ -40,7 +40,7 @@ function base16-atelier-plateau -d "Atelier Plateau"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-savanna-light.fish
+++ b/functions/base16-atelier-savanna-light.fish
@@ -40,7 +40,7 @@ function base16-atelier-savanna-light -d "Atelier Savanna Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-savanna.fish
+++ b/functions/base16-atelier-savanna.fish
@@ -40,7 +40,7 @@ function base16-atelier-savanna -d "Atelier Savanna"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-seaside-light.fish
+++ b/functions/base16-atelier-seaside-light.fish
@@ -40,7 +40,7 @@ function base16-atelier-seaside-light -d "Atelier Seaside Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-seaside.fish
+++ b/functions/base16-atelier-seaside.fish
@@ -40,7 +40,7 @@ function base16-atelier-seaside -d "Atelier Seaside"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-sulphurpool-light.fish
+++ b/functions/base16-atelier-sulphurpool-light.fish
@@ -40,7 +40,7 @@ function base16-atelier-sulphurpool-light -d "Atelier Sulphurpool Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atelier-sulphurpool.fish
+++ b/functions/base16-atelier-sulphurpool.fish
@@ -40,7 +40,7 @@ function base16-atelier-sulphurpool -d "Atelier Sulphurpool"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-atlas.fish
+++ b/functions/base16-atlas.fish
@@ -40,7 +40,7 @@ function base16-atlas -d "Atlas"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-bespin.fish
+++ b/functions/base16-bespin.fish
@@ -40,7 +40,7 @@ function base16-bespin -d "Bespin"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-black-metal-bathory.fish
+++ b/functions/base16-black-metal-bathory.fish
@@ -40,7 +40,7 @@ function base16-black-metal-bathory -d "Black Metal (Bathory)"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-black-metal-burzum.fish
+++ b/functions/base16-black-metal-burzum.fish
@@ -40,7 +40,7 @@ function base16-black-metal-burzum -d "Black Metal (Burzum)"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-black-metal-dark-funeral.fish
+++ b/functions/base16-black-metal-dark-funeral.fish
@@ -40,7 +40,7 @@ function base16-black-metal-dark-funeral -d "Black Metal (Dark Funeral)"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-black-metal-gorgoroth.fish
+++ b/functions/base16-black-metal-gorgoroth.fish
@@ -40,7 +40,7 @@ function base16-black-metal-gorgoroth -d "Black Metal (Gorgoroth)"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-black-metal-immortal.fish
+++ b/functions/base16-black-metal-immortal.fish
@@ -40,7 +40,7 @@ function base16-black-metal-immortal -d "Black Metal (Immortal)"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-black-metal-khold.fish
+++ b/functions/base16-black-metal-khold.fish
@@ -40,7 +40,7 @@ function base16-black-metal-khold -d "Black Metal (Khold)"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-black-metal-marduk.fish
+++ b/functions/base16-black-metal-marduk.fish
@@ -40,7 +40,7 @@ function base16-black-metal-marduk -d "Black Metal (Marduk)"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-black-metal-mayhem.fish
+++ b/functions/base16-black-metal-mayhem.fish
@@ -40,7 +40,7 @@ function base16-black-metal-mayhem -d "Black Metal (Mayhem)"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-black-metal-nile.fish
+++ b/functions/base16-black-metal-nile.fish
@@ -40,7 +40,7 @@ function base16-black-metal-nile -d "Black Metal (Nile)"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-black-metal-venom.fish
+++ b/functions/base16-black-metal-venom.fish
@@ -40,7 +40,7 @@ function base16-black-metal-venom -d "Black Metal (Venom)"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-black-metal.fish
+++ b/functions/base16-black-metal.fish
@@ -40,7 +40,7 @@ function base16-black-metal -d "Black Metal"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-brewer.fish
+++ b/functions/base16-brewer.fish
@@ -40,7 +40,7 @@ function base16-brewer -d "Brewer"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-bright.fish
+++ b/functions/base16-bright.fish
@@ -40,7 +40,7 @@ function base16-bright -d "Bright"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-brogrammer.fish
+++ b/functions/base16-brogrammer.fish
@@ -40,7 +40,7 @@ function base16-brogrammer -d "Brogrammer"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-brushtrees-dark.fish
+++ b/functions/base16-brushtrees-dark.fish
@@ -40,7 +40,7 @@ function base16-brushtrees-dark -d "Brush Trees Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-brushtrees.fish
+++ b/functions/base16-brushtrees.fish
@@ -40,7 +40,7 @@ function base16-brushtrees -d "Brush Trees"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-chalk.fish
+++ b/functions/base16-chalk.fish
@@ -40,7 +40,7 @@ function base16-chalk -d "Chalk"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-circus.fish
+++ b/functions/base16-circus.fish
@@ -40,7 +40,7 @@ function base16-circus -d "Circus"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-classic-dark.fish
+++ b/functions/base16-classic-dark.fish
@@ -40,7 +40,7 @@ function base16-classic-dark -d "Classic Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-classic-light.fish
+++ b/functions/base16-classic-light.fish
@@ -40,7 +40,7 @@ function base16-classic-light -d "Classic Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-codeschool.fish
+++ b/functions/base16-codeschool.fish
@@ -40,7 +40,7 @@ function base16-codeschool -d "Codeschool"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-cupcake.fish
+++ b/functions/base16-cupcake.fish
@@ -40,7 +40,7 @@ function base16-cupcake -d "Cupcake"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-cupertino.fish
+++ b/functions/base16-cupertino.fish
@@ -40,7 +40,7 @@ function base16-cupertino -d "Cupertino"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-darktooth.fish
+++ b/functions/base16-darktooth.fish
@@ -40,7 +40,7 @@ function base16-darktooth -d "Darktooth"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-default-dark.fish
+++ b/functions/base16-default-dark.fish
@@ -40,7 +40,7 @@ function base16-default-dark -d "Default Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-default-light.fish
+++ b/functions/base16-default-light.fish
@@ -40,7 +40,7 @@ function base16-default-light -d "Default Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-dracula.fish
+++ b/functions/base16-dracula.fish
@@ -40,7 +40,7 @@ function base16-dracula -d "Dracula"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-eighties.fish
+++ b/functions/base16-eighties.fish
@@ -40,7 +40,7 @@ function base16-eighties -d "Eighties"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-embers.fish
+++ b/functions/base16-embers.fish
@@ -40,7 +40,7 @@ function base16-embers -d "Embers"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-flat.fish
+++ b/functions/base16-flat.fish
@@ -40,7 +40,7 @@ function base16-flat -d "Flat"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-framer.fish
+++ b/functions/base16-framer.fish
@@ -40,7 +40,7 @@ function base16-framer -d "Framer"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-fruit-soda.fish
+++ b/functions/base16-fruit-soda.fish
@@ -40,7 +40,7 @@ function base16-fruit-soda -d "Fruit Soda"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-github.fish
+++ b/functions/base16-github.fish
@@ -40,7 +40,7 @@ function base16-github -d "Github"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-google-dark.fish
+++ b/functions/base16-google-dark.fish
@@ -40,7 +40,7 @@ function base16-google-dark -d "Google Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-google-light.fish
+++ b/functions/base16-google-light.fish
@@ -40,7 +40,7 @@ function base16-google-light -d "Google Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-grayscale-dark.fish
+++ b/functions/base16-grayscale-dark.fish
@@ -40,7 +40,7 @@ function base16-grayscale-dark -d "Grayscale Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-grayscale-light.fish
+++ b/functions/base16-grayscale-light.fish
@@ -40,7 +40,7 @@ function base16-grayscale-light -d "Grayscale Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-greenscreen.fish
+++ b/functions/base16-greenscreen.fish
@@ -40,7 +40,7 @@ function base16-greenscreen -d "Green Screen"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-gruvbox-dark-hard.fish
+++ b/functions/base16-gruvbox-dark-hard.fish
@@ -40,7 +40,7 @@ function base16-gruvbox-dark-hard -d "Gruvbox dark, hard"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-gruvbox-dark-medium.fish
+++ b/functions/base16-gruvbox-dark-medium.fish
@@ -40,7 +40,7 @@ function base16-gruvbox-dark-medium -d "Gruvbox dark, medium"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-gruvbox-dark-pale.fish
+++ b/functions/base16-gruvbox-dark-pale.fish
@@ -40,7 +40,7 @@ function base16-gruvbox-dark-pale -d "Gruvbox dark, pale"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-gruvbox-dark-soft.fish
+++ b/functions/base16-gruvbox-dark-soft.fish
@@ -40,7 +40,7 @@ function base16-gruvbox-dark-soft -d "Gruvbox dark, soft"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-gruvbox-light-hard.fish
+++ b/functions/base16-gruvbox-light-hard.fish
@@ -40,7 +40,7 @@ function base16-gruvbox-light-hard -d "Gruvbox light, hard"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-gruvbox-light-medium.fish
+++ b/functions/base16-gruvbox-light-medium.fish
@@ -40,7 +40,7 @@ function base16-gruvbox-light-medium -d "Gruvbox light, medium"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-gruvbox-light-soft.fish
+++ b/functions/base16-gruvbox-light-soft.fish
@@ -40,7 +40,7 @@ function base16-gruvbox-light-soft -d "Gruvbox light, soft"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-harmonic-dark.fish
+++ b/functions/base16-harmonic-dark.fish
@@ -40,7 +40,7 @@ function base16-harmonic-dark -d "Harmonic16 Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-harmonic-light.fish
+++ b/functions/base16-harmonic-light.fish
@@ -40,7 +40,7 @@ function base16-harmonic-light -d "Harmonic16 Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-heetch-light.fish
+++ b/functions/base16-heetch-light.fish
@@ -40,7 +40,7 @@ function base16-heetch-light -d "Heetch Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-heetch.fish
+++ b/functions/base16-heetch.fish
@@ -40,7 +40,7 @@ function base16-heetch -d "Heetch Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-helios.fish
+++ b/functions/base16-helios.fish
@@ -40,7 +40,7 @@ function base16-helios -d "Helios"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-hopscotch.fish
+++ b/functions/base16-hopscotch.fish
@@ -40,7 +40,7 @@ function base16-hopscotch -d "Hopscotch"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-horizon-dark.fish
+++ b/functions/base16-horizon-dark.fish
@@ -40,7 +40,7 @@ function base16-horizon-dark -d "Horizon Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-horizon-light.fish
+++ b/functions/base16-horizon-light.fish
@@ -40,7 +40,7 @@ function base16-horizon-light -d "Horizon Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-horizon-terminal-dark.fish
+++ b/functions/base16-horizon-terminal-dark.fish
@@ -40,7 +40,7 @@ function base16-horizon-terminal-dark -d "Horizon Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-horizon-terminal-light.fish
+++ b/functions/base16-horizon-terminal-light.fish
@@ -40,7 +40,7 @@ function base16-horizon-terminal-light -d "Horizon Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-ia-dark.fish
+++ b/functions/base16-ia-dark.fish
@@ -40,7 +40,7 @@ function base16-ia-dark -d "iA Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-ia-light.fish
+++ b/functions/base16-ia-light.fish
@@ -40,7 +40,7 @@ function base16-ia-light -d "iA Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-icy.fish
+++ b/functions/base16-icy.fish
@@ -40,7 +40,7 @@ function base16-icy -d "Icy Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-irblack.fish
+++ b/functions/base16-irblack.fish
@@ -40,7 +40,7 @@ function base16-irblack -d "IR Black"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-isotope.fish
+++ b/functions/base16-isotope.fish
@@ -40,7 +40,7 @@ function base16-isotope -d "Isotope"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-macintosh.fish
+++ b/functions/base16-macintosh.fish
@@ -40,7 +40,7 @@ function base16-macintosh -d "Macintosh"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-marrakesh.fish
+++ b/functions/base16-marrakesh.fish
@@ -40,7 +40,7 @@ function base16-marrakesh -d "Marrakesh"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-materia.fish
+++ b/functions/base16-materia.fish
@@ -40,7 +40,7 @@ function base16-materia -d "Materia"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-material-darker.fish
+++ b/functions/base16-material-darker.fish
@@ -40,7 +40,7 @@ function base16-material-darker -d "Material Darker"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-material-lighter.fish
+++ b/functions/base16-material-lighter.fish
@@ -40,7 +40,7 @@ function base16-material-lighter -d "Material Lighter"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-material-palenight.fish
+++ b/functions/base16-material-palenight.fish
@@ -40,7 +40,7 @@ function base16-material-palenight -d "Material Palenight"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-material-vivid.fish
+++ b/functions/base16-material-vivid.fish
@@ -40,7 +40,7 @@ function base16-material-vivid -d "Material Vivid"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-material.fish
+++ b/functions/base16-material.fish
@@ -40,7 +40,7 @@ function base16-material -d "Material"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-mellow-purple.fish
+++ b/functions/base16-mellow-purple.fish
@@ -40,7 +40,7 @@ function base16-mellow-purple -d "Mellow Purple"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-mexico-light.fish
+++ b/functions/base16-mexico-light.fish
@@ -40,7 +40,7 @@ function base16-mexico-light -d "Mexico Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-mocha.fish
+++ b/functions/base16-mocha.fish
@@ -40,7 +40,7 @@ function base16-mocha -d "Mocha"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-monokai.fish
+++ b/functions/base16-monokai.fish
@@ -40,7 +40,7 @@ function base16-monokai -d "Monokai"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-nord.fish
+++ b/functions/base16-nord.fish
@@ -40,7 +40,7 @@ function base16-nord -d "Nord"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-ocean.fish
+++ b/functions/base16-ocean.fish
@@ -40,7 +40,7 @@ function base16-ocean -d "Ocean"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-oceanicnext.fish
+++ b/functions/base16-oceanicnext.fish
@@ -40,7 +40,7 @@ function base16-oceanicnext -d "OceanicNext"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-one-light.fish
+++ b/functions/base16-one-light.fish
@@ -40,7 +40,7 @@ function base16-one-light -d "One Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-onedark.fish
+++ b/functions/base16-onedark.fish
@@ -40,7 +40,7 @@ function base16-onedark -d "OneDark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-outrun-dark.fish
+++ b/functions/base16-outrun-dark.fish
@@ -40,7 +40,7 @@ function base16-outrun-dark -d "Outrun Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-papercolor-dark.fish
+++ b/functions/base16-papercolor-dark.fish
@@ -40,7 +40,7 @@ function base16-papercolor-dark -d "PaperColor Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-papercolor-light.fish
+++ b/functions/base16-papercolor-light.fish
@@ -40,7 +40,7 @@ function base16-papercolor-light -d "PaperColor Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-paraiso.fish
+++ b/functions/base16-paraiso.fish
@@ -40,7 +40,7 @@ function base16-paraiso -d "Paraiso"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-phd.fish
+++ b/functions/base16-phd.fish
@@ -40,7 +40,7 @@ function base16-phd -d "PhD"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-pico.fish
+++ b/functions/base16-pico.fish
@@ -40,7 +40,7 @@ function base16-pico -d "Pico"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-pop.fish
+++ b/functions/base16-pop.fish
@@ -40,7 +40,7 @@ function base16-pop -d "Pop"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-porple.fish
+++ b/functions/base16-porple.fish
@@ -40,7 +40,7 @@ function base16-porple -d "Porple"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-railscasts.fish
+++ b/functions/base16-railscasts.fish
@@ -40,7 +40,7 @@ function base16-railscasts -d "Railscasts"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-rebecca.fish
+++ b/functions/base16-rebecca.fish
@@ -40,7 +40,7 @@ function base16-rebecca -d "Rebecca"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-seti.fish
+++ b/functions/base16-seti.fish
@@ -40,7 +40,7 @@ function base16-seti -d "Seti UI"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-shapeshifter.fish
+++ b/functions/base16-shapeshifter.fish
@@ -40,7 +40,7 @@ function base16-shapeshifter -d "Shapeshifter"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-snazzy.fish
+++ b/functions/base16-snazzy.fish
@@ -40,7 +40,7 @@ function base16-snazzy -d "Snazzy"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-solarflare.fish
+++ b/functions/base16-solarflare.fish
@@ -40,7 +40,7 @@ function base16-solarflare -d "Solar Flare"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-solarized-dark.fish
+++ b/functions/base16-solarized-dark.fish
@@ -40,7 +40,7 @@ function base16-solarized-dark -d "Solarized Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-solarized-light.fish
+++ b/functions/base16-solarized-light.fish
@@ -40,7 +40,7 @@ function base16-solarized-light -d "Solarized Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-spacemacs.fish
+++ b/functions/base16-spacemacs.fish
@@ -40,7 +40,7 @@ function base16-spacemacs -d "Spacemacs"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-summerfruit-dark.fish
+++ b/functions/base16-summerfruit-dark.fish
@@ -40,7 +40,7 @@ function base16-summerfruit-dark -d "Summerfruit Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-summerfruit-light.fish
+++ b/functions/base16-summerfruit-light.fish
@@ -40,7 +40,7 @@ function base16-summerfruit-light -d "Summerfruit Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-synth-midnight-dark.fish
+++ b/functions/base16-synth-midnight-dark.fish
@@ -40,7 +40,7 @@ function base16-synth-midnight-dark -d "Synth Midnight Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-tomorrow-night-eighties.fish
+++ b/functions/base16-tomorrow-night-eighties.fish
@@ -40,7 +40,7 @@ function base16-tomorrow-night-eighties -d "Tomorrow Night"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-tomorrow-night.fish
+++ b/functions/base16-tomorrow-night.fish
@@ -40,7 +40,7 @@ function base16-tomorrow-night -d "Tomorrow Night"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-tomorrow.fish
+++ b/functions/base16-tomorrow.fish
@@ -40,7 +40,7 @@ function base16-tomorrow -d "Tomorrow"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-tube.fish
+++ b/functions/base16-tube.fish
@@ -40,7 +40,7 @@ function base16-tube -d "London Tube"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-twilight.fish
+++ b/functions/base16-twilight.fish
@@ -40,7 +40,7 @@ function base16-twilight -d "Twilight"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-unikitty-dark.fish
+++ b/functions/base16-unikitty-dark.fish
@@ -40,7 +40,7 @@ function base16-unikitty-dark -d "Unikitty Dark"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-unikitty-light.fish
+++ b/functions/base16-unikitty-light.fish
@@ -40,7 +40,7 @@ function base16-unikitty-light -d "Unikitty Light"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-woodland.fish
+++ b/functions/base16-woodland.fish
@@ -40,7 +40,7 @@ function base16-woodland -d "Woodland"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-xcode-dusk.fish
+++ b/functions/base16-xcode-dusk.fish
@@ -40,7 +40,7 @@ function base16-xcode-dusk -d "XCode Dusk"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/functions/base16-zenburn.fish
+++ b/functions/base16-zenburn.fish
@@ -40,7 +40,7 @@ function base16-zenburn -d "Zenburn"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $2 | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -40,7 +40,7 @@ function base16-{{scheme-slug}} -d "{{scheme-name}}"
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
   else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
-    function put_template; test $1 -lt 16 && printf "\e]P%x%s" $1 (echo $2 | sed 's/\///g'); end;
+    function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
   else


### PR DESCRIPTION
Changed `$1` and `$2` in line 43 of all function files to `$argv[1]` and `$argv[2]`, as suggested on issue #4 by @ccryx.
Also updated installation instructions on `README.md` to match fisher 4 syntax (`install` instead of `add`).