### PR TITLE
Use white for param color

### DIFF
--- a/functions/base16-3024.fish
+++ b/functions/base16-3024.fish
@@ -111,7 +111,7 @@ function base16-3024 -d "3024"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 807d7c
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=4a4543

--- a/functions/base16-apathy.fish
+++ b/functions/base16-apathy.fish
@@ -111,7 +111,7 @@ function base16-apathy -d "Apathy"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 5F9C92
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=184E45

--- a/functions/base16-apprentice.fish
+++ b/functions/base16-apprentice.fish
@@ -111,7 +111,7 @@ function base16-apprentice -d "Apprentice"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 787878
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=333333

--- a/functions/base16-ashes.fish
+++ b/functions/base16-ashes.fish
@@ -111,7 +111,7 @@ function base16-ashes -d "Ashes"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param ADB3BA
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=565E65

--- a/functions/base16-atelier-cave-light.fish
+++ b/functions/base16-atelier-cave-light.fish
@@ -111,7 +111,7 @@ function base16-atelier-cave-light -d "Atelier Cave Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 655f6d
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=8b8792

--- a/functions/base16-atelier-cave.fish
+++ b/functions/base16-atelier-cave.fish
@@ -111,7 +111,7 @@ function base16-atelier-cave -d "Atelier Cave"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 7e7887
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=585260

--- a/functions/base16-atelier-dune-light.fish
+++ b/functions/base16-atelier-dune-light.fish
@@ -111,7 +111,7 @@ function base16-atelier-dune-light -d "Atelier Dune Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 7d7a68
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=a6a28c

--- a/functions/base16-atelier-dune.fish
+++ b/functions/base16-atelier-dune.fish
@@ -111,7 +111,7 @@ function base16-atelier-dune -d "Atelier Dune"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 999580
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=6e6b5e

--- a/functions/base16-atelier-estuary-light.fish
+++ b/functions/base16-atelier-estuary-light.fish
@@ -111,7 +111,7 @@ function base16-atelier-estuary-light -d "Atelier Estuary Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 6c6b5a
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=929181

--- a/functions/base16-atelier-estuary.fish
+++ b/functions/base16-atelier-estuary.fish
@@ -111,7 +111,7 @@ function base16-atelier-estuary -d "Atelier Estuary"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 878573
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=5f5e4e

--- a/functions/base16-atelier-forest-light.fish
+++ b/functions/base16-atelier-forest-light.fish
@@ -111,7 +111,7 @@ function base16-atelier-forest-light -d "Atelier Forest Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 766e6b
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=a8a19f

--- a/functions/base16-atelier-forest.fish
+++ b/functions/base16-atelier-forest.fish
@@ -111,7 +111,7 @@ function base16-atelier-forest -d "Atelier Forest"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 9c9491
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=68615e

--- a/functions/base16-atelier-heath-light.fish
+++ b/functions/base16-atelier-heath-light.fish
@@ -111,7 +111,7 @@ function base16-atelier-heath-light -d "Atelier Heath Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 776977
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=ab9bab

--- a/functions/base16-atelier-heath.fish
+++ b/functions/base16-atelier-heath.fish
@@ -111,7 +111,7 @@ function base16-atelier-heath -d "Atelier Heath"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 9e8f9e
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=695d69

--- a/functions/base16-atelier-lakeside-light.fish
+++ b/functions/base16-atelier-lakeside-light.fish
@@ -111,7 +111,7 @@ function base16-atelier-lakeside-light -d "Atelier Lakeside Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 5a7b8c
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=7ea2b4

--- a/functions/base16-atelier-lakeside.fish
+++ b/functions/base16-atelier-lakeside.fish
@@ -111,7 +111,7 @@ function base16-atelier-lakeside -d "Atelier Lakeside"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 7195a8
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=516d7b

--- a/functions/base16-atelier-plateau-light.fish
+++ b/functions/base16-atelier-plateau-light.fish
@@ -111,7 +111,7 @@ function base16-atelier-plateau-light -d "Atelier Plateau Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 655d5d
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=8a8585

--- a/functions/base16-atelier-plateau.fish
+++ b/functions/base16-atelier-plateau.fish
@@ -111,7 +111,7 @@ function base16-atelier-plateau -d "Atelier Plateau"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 7e7777
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=585050

--- a/functions/base16-atelier-savanna-light.fish
+++ b/functions/base16-atelier-savanna-light.fish
@@ -111,7 +111,7 @@ function base16-atelier-savanna-light -d "Atelier Savanna Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 5f6d64
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=87928a

--- a/functions/base16-atelier-savanna.fish
+++ b/functions/base16-atelier-savanna.fish
@@ -111,7 +111,7 @@ function base16-atelier-savanna -d "Atelier Savanna"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 78877d
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=526057

--- a/functions/base16-atelier-seaside-light.fish
+++ b/functions/base16-atelier-seaside-light.fish
@@ -111,7 +111,7 @@ function base16-atelier-seaside-light -d "Atelier Seaside Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 687d68
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=8ca68c

--- a/functions/base16-atelier-seaside.fish
+++ b/functions/base16-atelier-seaside.fish
@@ -111,7 +111,7 @@ function base16-atelier-seaside -d "Atelier Seaside"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 809980
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=5e6e5e

--- a/functions/base16-atelier-sulphurpool-light.fish
+++ b/functions/base16-atelier-sulphurpool-light.fish
@@ -111,7 +111,7 @@ function base16-atelier-sulphurpool-light -d "Atelier Sulphurpool Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 6b7394
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=979db4

--- a/functions/base16-atelier-sulphurpool.fish
+++ b/functions/base16-atelier-sulphurpool.fish
@@ -111,7 +111,7 @@ function base16-atelier-sulphurpool -d "Atelier Sulphurpool"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 898ea4
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=5e6687

--- a/functions/base16-atlas.fish
+++ b/functions/base16-atlas.fish
@@ -111,7 +111,7 @@ function base16-atlas -d "Atlas"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 869696
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=517F8D

--- a/functions/base16-bespin.fish
+++ b/functions/base16-bespin.fish
@@ -111,7 +111,7 @@ function base16-bespin -d "Bespin"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 797977
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=5e5d5c

--- a/functions/base16-black-metal-bathory.fish
+++ b/functions/base16-black-metal-bathory.fish
@@ -111,7 +111,7 @@ function base16-black-metal-bathory -d "Black Metal (Bathory)"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 999999
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=222222

--- a/functions/base16-black-metal-burzum.fish
+++ b/functions/base16-black-metal-burzum.fish
@@ -111,7 +111,7 @@ function base16-black-metal-burzum -d "Black Metal (Burzum)"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 999999
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=222222

--- a/functions/base16-black-metal-dark-funeral.fish
+++ b/functions/base16-black-metal-dark-funeral.fish
@@ -111,7 +111,7 @@ function base16-black-metal-dark-funeral -d "Black Metal (Dark Funeral)"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 999999
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=222222

--- a/functions/base16-black-metal-gorgoroth.fish
+++ b/functions/base16-black-metal-gorgoroth.fish
@@ -111,7 +111,7 @@ function base16-black-metal-gorgoroth -d "Black Metal (Gorgoroth)"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 999999
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=222222

--- a/functions/base16-black-metal-immortal.fish
+++ b/functions/base16-black-metal-immortal.fish
@@ -111,7 +111,7 @@ function base16-black-metal-immortal -d "Black Metal (Immortal)"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 999999
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=222222

--- a/functions/base16-black-metal-khold.fish
+++ b/functions/base16-black-metal-khold.fish
@@ -111,7 +111,7 @@ function base16-black-metal-khold -d "Black Metal (Khold)"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 999999
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=222222

--- a/functions/base16-black-metal-marduk.fish
+++ b/functions/base16-black-metal-marduk.fish
@@ -111,7 +111,7 @@ function base16-black-metal-marduk -d "Black Metal (Marduk)"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 999999
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=222222

--- a/functions/base16-black-metal-mayhem.fish
+++ b/functions/base16-black-metal-mayhem.fish
@@ -111,7 +111,7 @@ function base16-black-metal-mayhem -d "Black Metal (Mayhem)"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 999999
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=222222

--- a/functions/base16-black-metal-nile.fish
+++ b/functions/base16-black-metal-nile.fish
@@ -111,7 +111,7 @@ function base16-black-metal-nile -d "Black Metal (Nile)"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 999999
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=222222

--- a/functions/base16-black-metal-venom.fish
+++ b/functions/base16-black-metal-venom.fish
@@ -111,7 +111,7 @@ function base16-black-metal-venom -d "Black Metal (Venom)"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 999999
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=222222

--- a/functions/base16-black-metal.fish
+++ b/functions/base16-black-metal.fish
@@ -111,7 +111,7 @@ function base16-black-metal -d "Black Metal"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 999999
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=222222

--- a/functions/base16-brewer.fish
+++ b/functions/base16-brewer.fish
@@ -111,7 +111,7 @@ function base16-brewer -d "Brewer"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 959697
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=515253

--- a/functions/base16-bright.fish
+++ b/functions/base16-bright.fish
@@ -111,7 +111,7 @@ function base16-bright -d "Bright"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param d0d0d0
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=505050

--- a/functions/base16-brogrammer.fish
+++ b/functions/base16-brogrammer.fish
@@ -111,7 +111,7 @@ function base16-brogrammer -d "Brogrammer"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 2a84d2
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=2dc55e

--- a/functions/base16-brushtrees-dark.fish
+++ b/functions/base16-brushtrees-dark.fish
@@ -111,7 +111,7 @@ function base16-brushtrees-dark -d "Brush Trees Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 98AFB5
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=6D828E

--- a/functions/base16-brushtrees.fish
+++ b/functions/base16-brushtrees.fish
@@ -111,7 +111,7 @@ function base16-brushtrees -d "Brush Trees"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 8299A1
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=B0C5C8

--- a/functions/base16-chalk.fish
+++ b/functions/base16-chalk.fish
@@ -111,7 +111,7 @@ function base16-chalk -d "Chalk"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b0b0b0
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=303030

--- a/functions/base16-circus.fish
+++ b/functions/base16-circus.fish
@@ -111,7 +111,7 @@ function base16-circus -d "Circus"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 505050
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=303030

--- a/functions/base16-classic-dark.fish
+++ b/functions/base16-classic-dark.fish
@@ -111,7 +111,7 @@ function base16-classic-dark -d "Classic Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param B0B0B0
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=303030

--- a/functions/base16-classic-light.fish
+++ b/functions/base16-classic-light.fish
@@ -111,7 +111,7 @@ function base16-classic-light -d "Classic Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 505050
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=D0D0D0

--- a/functions/base16-codeschool.fish
+++ b/functions/base16-codeschool.fish
@@ -111,7 +111,7 @@ function base16-codeschool -d "Codeschool"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 84898c
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=2a343a

--- a/functions/base16-colors.fish
+++ b/functions/base16-colors.fish
@@ -111,7 +111,7 @@ function base16-colors -d "Colors"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 999999
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=555555

--- a/functions/base16-cupcake.fish
+++ b/functions/base16-cupcake.fish
@@ -111,7 +111,7 @@ function base16-cupcake -d "Cupcake"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param a59daf
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d8d5dd

--- a/functions/base16-cupertino.fish
+++ b/functions/base16-cupertino.fish
@@ -111,7 +111,7 @@ function base16-cupertino -d "Cupertino"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 808080
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=c0c0c0

--- a/functions/base16-danqing.fish
+++ b/functions/base16-danqing.fish
@@ -111,7 +111,7 @@ function base16-danqing -d "DanQing"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param cad8d2
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=5a605d

--- a/functions/base16-darcula.fish
+++ b/functions/base16-darcula.fish
@@ -111,7 +111,7 @@ function base16-darcula -d "Darcula"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param a4a3a3
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=323232

--- a/functions/base16-darkmoss.fish
+++ b/functions/base16-darkmoss.fish
@@ -111,7 +111,7 @@ function base16-darkmoss -d "darkmoss"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 818f80
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=373c3d

--- a/functions/base16-darktooth.fish
+++ b/functions/base16-darktooth.fish
@@ -111,7 +111,7 @@ function base16-darktooth -d "Darktooth"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 928374
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=504945

--- a/functions/base16-darkviolet.fish
+++ b/functions/base16-darkviolet.fish
@@ -111,7 +111,7 @@ function base16-darkviolet -d "Dark Violet"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 00ff00
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=432d59

--- a/functions/base16-decaf.fish
+++ b/functions/base16-decaf.fish
@@ -111,7 +111,7 @@ function base16-decaf -d "Decaf"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b4b7b4
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=515151

--- a/functions/base16-default-dark.fish
+++ b/functions/base16-default-dark.fish
@@ -111,7 +111,7 @@ function base16-default-dark -d "Default Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b8b8b8
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=383838

--- a/functions/base16-default-light.fish
+++ b/functions/base16-default-light.fish
@@ -111,7 +111,7 @@ function base16-default-light -d "Default Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 585858
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d8d8d8

--- a/functions/base16-dirtysea.fish
+++ b/functions/base16-dirtysea.fish
@@ -111,7 +111,7 @@ function base16-dirtysea -d "dirtysea"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 202020
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d0d0d0

--- a/functions/base16-dracula.fish
+++ b/functions/base16-dracula.fish
@@ -111,7 +111,7 @@ function base16-dracula -d "Dracula"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 62d6e8
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=4d4f68

--- a/functions/base16-edge-dark.fish
+++ b/functions/base16-edge-dark.fish
@@ -111,7 +111,7 @@ function base16-edge-dark -d "Edge Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 73b3e7
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=b7bec9

--- a/functions/base16-edge-light.fish
+++ b/functions/base16-edge-light.fish
@@ -111,7 +111,7 @@ function base16-edge-light -d "Edge Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 6587bf
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d69822

--- a/functions/base16-eighties.fish
+++ b/functions/base16-eighties.fish
@@ -111,7 +111,7 @@ function base16-eighties -d "Eighties"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param a09f93
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=515151

--- a/functions/base16-embers.fish
+++ b/functions/base16-embers.fish
@@ -111,7 +111,7 @@ function base16-embers -d "Embers"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 8A8075
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=433B32

--- a/functions/base16-equilibrium-dark.fish
+++ b/functions/base16-equilibrium-dark.fish
@@ -111,7 +111,7 @@ function base16-equilibrium-dark -d "Equilibrium Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 949088
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=22262d

--- a/functions/base16-equilibrium-gray-dark.fish
+++ b/functions/base16-equilibrium-gray-dark.fish
@@ -111,7 +111,7 @@ function base16-equilibrium-gray-dark -d "Equilibrium Gray Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 919191
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=262626

--- a/functions/base16-equilibrium-gray-light.fish
+++ b/functions/base16-equilibrium-gray-light.fish
@@ -111,7 +111,7 @@ function base16-equilibrium-gray-light -d "Equilibrium Gray Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 5e5e5e
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d4d4d4

--- a/functions/base16-equilibrium-light.fish
+++ b/functions/base16-equilibrium-light.fish
@@ -111,7 +111,7 @@ function base16-equilibrium-light -d "Equilibrium Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 5a5f66
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d8d4cb

--- a/functions/base16-espresso.fish
+++ b/functions/base16-espresso.fish
@@ -111,7 +111,7 @@ function base16-espresso -d "Espresso"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b4b7b4
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=515151

--- a/functions/base16-eva-dim.fish
+++ b/functions/base16-eva-dim.fish
@@ -111,7 +111,7 @@ function base16-eva-dim -d "Eva Dim"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 7e90a3
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=4b6988

--- a/functions/base16-eva.fish
+++ b/functions/base16-eva.fish
@@ -111,7 +111,7 @@ function base16-eva -d "Eva"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 7e90a3
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=4b6988

--- a/functions/base16-flat.fish
+++ b/functions/base16-flat.fish
@@ -111,7 +111,7 @@ function base16-flat -d "Flat"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param BDC3C7
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=7F8C8D

--- a/functions/base16-framer.fish
+++ b/functions/base16-framer.fish
@@ -111,7 +111,7 @@ function base16-framer -d "Framer"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param B9B9B9
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=464646

--- a/functions/base16-fruit-soda.fish
+++ b/functions/base16-fruit-soda.fish
@@ -111,7 +111,7 @@ function base16-fruit-soda -d "Fruit Soda"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 979598
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d8d5d5

--- a/functions/base16-gigavolt.fish
+++ b/functions/base16-gigavolt.fish
@@ -111,7 +111,7 @@ function base16-gigavolt -d "Gigavolt"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param cad3ff
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=5a576e

--- a/functions/base16-github.fish
+++ b/functions/base16-github.fish
@@ -111,7 +111,7 @@ function base16-github -d "Github"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param e8e8e8
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=c8c8fa

--- a/functions/base16-google-dark.fish
+++ b/functions/base16-google-dark.fish
@@ -111,7 +111,7 @@ function base16-google-dark -d "Google Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b4b7b4
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=373b41

--- a/functions/base16-google-light.fish
+++ b/functions/base16-google-light.fish
@@ -111,7 +111,7 @@ function base16-google-light -d "Google Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 969896
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=c5c8c6

--- a/functions/base16-grayscale-dark.fish
+++ b/functions/base16-grayscale-dark.fish
@@ -111,7 +111,7 @@ function base16-grayscale-dark -d "Grayscale Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param ababab
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=464646

--- a/functions/base16-grayscale-light.fish
+++ b/functions/base16-grayscale-light.fish
@@ -111,7 +111,7 @@ function base16-grayscale-light -d "Grayscale Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 525252
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=b9b9b9

--- a/functions/base16-greenscreen.fish
+++ b/functions/base16-greenscreen.fish
@@ -111,7 +111,7 @@ function base16-greenscreen -d "Green Screen"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 009900
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=005500

--- a/functions/base16-gruvbox-dark-hard.fish
+++ b/functions/base16-gruvbox-dark-hard.fish
@@ -111,7 +111,7 @@ function base16-gruvbox-dark-hard -d "Gruvbox dark, hard"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param bdae93
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=504945

--- a/functions/base16-gruvbox-dark-medium.fish
+++ b/functions/base16-gruvbox-dark-medium.fish
@@ -111,7 +111,7 @@ function base16-gruvbox-dark-medium -d "Gruvbox dark, medium"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param bdae93
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=504945

--- a/functions/base16-gruvbox-dark-pale.fish
+++ b/functions/base16-gruvbox-dark-pale.fish
@@ -111,7 +111,7 @@ function base16-gruvbox-dark-pale -d "Gruvbox dark, pale"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 949494
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=4e4e4e

--- a/functions/base16-gruvbox-dark-soft.fish
+++ b/functions/base16-gruvbox-dark-soft.fish
@@ -111,7 +111,7 @@ function base16-gruvbox-dark-soft -d "Gruvbox dark, soft"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param bdae93
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=504945

--- a/functions/base16-gruvbox-light-hard.fish
+++ b/functions/base16-gruvbox-light-hard.fish
@@ -111,7 +111,7 @@ function base16-gruvbox-light-hard -d "Gruvbox light, hard"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 665c54
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d5c4a1

--- a/functions/base16-gruvbox-light-medium.fish
+++ b/functions/base16-gruvbox-light-medium.fish
@@ -111,7 +111,7 @@ function base16-gruvbox-light-medium -d "Gruvbox light, medium"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 665c54
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d5c4a1

--- a/functions/base16-gruvbox-light-soft.fish
+++ b/functions/base16-gruvbox-light-soft.fish
@@ -111,7 +111,7 @@ function base16-gruvbox-light-soft -d "Gruvbox light, soft"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 665c54
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d5c4a1

--- a/functions/base16-hardcore.fish
+++ b/functions/base16-hardcore.fish
@@ -111,7 +111,7 @@ function base16-hardcore -d "Hardcore"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 707070
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=353535

--- a/functions/base16-harmonic-dark.fish
+++ b/functions/base16-harmonic-dark.fish
@@ -111,7 +111,7 @@ function base16-harmonic-dark -d "Harmonic16 Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param aabcce
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=405c79

--- a/functions/base16-harmonic-light.fish
+++ b/functions/base16-harmonic-light.fish
@@ -111,7 +111,7 @@ function base16-harmonic-light -d "Harmonic16 Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 627e99
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=cbd6e2

--- a/functions/base16-heetch-light.fish
+++ b/functions/base16-heetch-light.fish
@@ -111,7 +111,7 @@ function base16-heetch-light -d "Heetch Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param ddd6e5
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=7b6d8b

--- a/functions/base16-heetch.fish
+++ b/functions/base16-heetch.fish
@@ -111,7 +111,7 @@ function base16-heetch -d "Heetch Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 9C92A8
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=5A496E

--- a/functions/base16-helios.fish
+++ b/functions/base16-helios.fish
@@ -111,7 +111,7 @@ function base16-helios -d "Helios"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param cdcdcd
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=53585b

--- a/functions/base16-hopscotch.fish
+++ b/functions/base16-hopscotch.fish
@@ -111,7 +111,7 @@ function base16-hopscotch -d "Hopscotch"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 989498
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=5c545b

--- a/functions/base16-horizon-dark.fish
+++ b/functions/base16-horizon-dark.fish
@@ -111,7 +111,7 @@ function base16-horizon-dark -d "Horizon Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 9DA0A2
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=2E303E

--- a/functions/base16-horizon-light.fish
+++ b/functions/base16-horizon-light.fish
@@ -111,7 +111,7 @@ function base16-horizon-light -d "Horizon Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 948C8A
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=F9CBBE

--- a/functions/base16-horizon-terminal-dark.fish
+++ b/functions/base16-horizon-terminal-dark.fish
@@ -111,7 +111,7 @@ function base16-horizon-terminal-dark -d "Horizon Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 9DA0A2
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=2E303E

--- a/functions/base16-horizon-terminal-light.fish
+++ b/functions/base16-horizon-terminal-light.fish
@@ -111,7 +111,7 @@ function base16-horizon-terminal-light -d "Horizon Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 948C8A
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=F9CBBE

--- a/functions/base16-humanoid-dark.fish
+++ b/functions/base16-humanoid-dark.fish
@@ -111,7 +111,7 @@ function base16-humanoid-dark -d "Humanoid dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param c0c0bd
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=484e54

--- a/functions/base16-humanoid-light.fish
+++ b/functions/base16-humanoid-light.fish
@@ -111,7 +111,7 @@ function base16-humanoid-light -d "Humanoid light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 60615d
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=deded8

--- a/functions/base16-ia-dark.fish
+++ b/functions/base16-ia-dark.fish
@@ -111,7 +111,7 @@ function base16-ia-dark -d "iA Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b8b8b8
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=1d414d

--- a/functions/base16-ia-light.fish
+++ b/functions/base16-ia-light.fish
@@ -111,7 +111,7 @@ function base16-ia-light -d "iA Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 767676
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=bde5f2

--- a/functions/base16-icy.fish
+++ b/functions/base16-icy.fish
@@ -111,7 +111,7 @@ function base16-icy -d "Icy Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 064048
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=041f23

--- a/functions/base16-irblack.fish
+++ b/functions/base16-irblack.fish
@@ -111,7 +111,7 @@ function base16-irblack -d "IR Black"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 918f88
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=484844

--- a/functions/base16-isotope.fish
+++ b/functions/base16-isotope.fish
@@ -111,7 +111,7 @@ function base16-isotope -d "Isotope"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param c0c0c0
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=606060

--- a/functions/base16-kimber.fish
+++ b/functions/base16-kimber.fish
@@ -111,7 +111,7 @@ function base16-kimber -d "Kimber"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 5A5A5A
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=555D55

--- a/functions/base16-macintosh.fish
+++ b/functions/base16-macintosh.fish
@@ -111,7 +111,7 @@ function base16-macintosh -d "Macintosh"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 808080
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=404040

--- a/functions/base16-marrakesh.fish
+++ b/functions/base16-marrakesh.fish
@@ -111,7 +111,7 @@ function base16-marrakesh -d "Marrakesh"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 86813b
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=5f5b17

--- a/functions/base16-materia.fish
+++ b/functions/base16-materia.fish
@@ -111,7 +111,7 @@ function base16-materia -d "Materia"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param C9CCD3
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=37474F

--- a/functions/base16-material-darker.fish
+++ b/functions/base16-material-darker.fish
@@ -111,7 +111,7 @@ function base16-material-darker -d "Material Darker"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param B2CCD6
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=353535

--- a/functions/base16-material-lighter.fish
+++ b/functions/base16-material-lighter.fish
@@ -111,7 +111,7 @@ function base16-material-lighter -d "Material Lighter"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 8796B0
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=CCEAE7

--- a/functions/base16-material-palenight.fish
+++ b/functions/base16-material-palenight.fish
@@ -111,7 +111,7 @@ function base16-material-palenight -d "Material Palenight"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 8796B0
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=32374D

--- a/functions/base16-material-vivid.fish
+++ b/functions/base16-material-vivid.fish
@@ -111,7 +111,7 @@ function base16-material-vivid -d "Material Vivid"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 676c71
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=323639

--- a/functions/base16-material.fish
+++ b/functions/base16-material.fish
@@ -111,7 +111,7 @@ function base16-material -d "Material"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param B2CCD6
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=314549

--- a/functions/base16-mellow-purple.fish
+++ b/functions/base16-mellow-purple.fish
@@ -111,7 +111,7 @@ function base16-mellow-purple -d "Mellow Purple"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 873582
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=331354

--- a/functions/base16-mexico-light.fish
+++ b/functions/base16-mexico-light.fish
@@ -111,7 +111,7 @@ function base16-mexico-light -d "Mexico Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 585858
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d8d8d8

--- a/functions/base16-mocha.fish
+++ b/functions/base16-mocha.fish
@@ -111,7 +111,7 @@ function base16-mocha -d "Mocha"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b8afad
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=645240

--- a/functions/base16-monokai.fish
+++ b/functions/base16-monokai.fish
@@ -111,7 +111,7 @@ function base16-monokai -d "Monokai"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param a59f85
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=49483e

--- a/functions/base16-nebula.fish
+++ b/functions/base16-nebula.fish
@@ -111,7 +111,7 @@ function base16-nebula -d "Nebula"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 87888b
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=5a8380

--- a/functions/base16-nord.fish
+++ b/functions/base16-nord.fish
@@ -111,7 +111,7 @@ function base16-nord -d "Nord"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param D8DEE9
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=434C5E

--- a/functions/base16-nova.fish
+++ b/functions/base16-nova.fish
@@ -111,7 +111,7 @@ function base16-nova -d "Nova"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 899BA6
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=6A7D89

--- a/functions/base16-ocean.fish
+++ b/functions/base16-ocean.fish
@@ -111,7 +111,7 @@ function base16-ocean -d "Ocean"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param a7adba
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=4f5b66

--- a/functions/base16-oceanicnext.fish
+++ b/functions/base16-oceanicnext.fish
@@ -111,7 +111,7 @@ function base16-oceanicnext -d "OceanicNext"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param A7ADBA
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=4F5B66

--- a/functions/base16-one-light.fish
+++ b/functions/base16-one-light.fish
@@ -111,7 +111,7 @@ function base16-one-light -d "One Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 696c77
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=e5e5e6

--- a/functions/base16-onedark.fish
+++ b/functions/base16-onedark.fish
@@ -111,7 +111,7 @@ function base16-onedark -d "OneDark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 565c64
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=3e4451

--- a/functions/base16-outrun-dark.fish
+++ b/functions/base16-outrun-dark.fish
@@ -111,7 +111,7 @@ function base16-outrun-dark -d "Outrun Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param B0B0DA
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=30305A

--- a/functions/base16-papercolor-dark.fish
+++ b/functions/base16-papercolor-dark.fish
@@ -111,7 +111,7 @@ function base16-papercolor-dark -d "PaperColor Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 5fafd7
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=5faf00

--- a/functions/base16-papercolor-light.fish
+++ b/functions/base16-papercolor-light.fish
@@ -111,7 +111,7 @@ function base16-papercolor-light -d "PaperColor Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 0087af
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=008700

--- a/functions/base16-paraiso.fish
+++ b/functions/base16-paraiso.fish
@@ -111,7 +111,7 @@ function base16-paraiso -d "Paraiso"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 8d8687
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=4f424c

--- a/functions/base16-pasque.fish
+++ b/functions/base16-pasque.fish
@@ -111,7 +111,7 @@ function base16-pasque -d "Pasque"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param BEBCBF
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=3E2D5C

--- a/functions/base16-phd.fish
+++ b/functions/base16-phd.fish
@@ -111,7 +111,7 @@ function base16-phd -d "PhD"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 9a99a3
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=4d5666

--- a/functions/base16-pico.fish
+++ b/functions/base16-pico.fish
@@ -111,7 +111,7 @@ function base16-pico -d "Pico"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param ab5236
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=7e2553

--- a/functions/base16-pinky.fish
+++ b/functions/base16-pinky.fish
@@ -111,7 +111,7 @@ function base16-pinky -d "pinky"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param e7dbdb
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=1d1b1d

--- a/functions/base16-pop.fish
+++ b/functions/base16-pop.fish
@@ -111,7 +111,7 @@ function base16-pop -d "Pop"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b0b0b0
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=303030

--- a/functions/base16-porple.fish
+++ b/functions/base16-porple.fish
@@ -111,7 +111,7 @@ function base16-porple -d "Porple"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b8b8b8
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=474160

--- a/functions/base16-qualia.fish
+++ b/functions/base16-qualia.fish
@@ -111,7 +111,7 @@ function base16-qualia -d "Qualia"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 808080
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=454545

--- a/functions/base16-railscasts.fish
+++ b/functions/base16-railscasts.fish
@@ -111,7 +111,7 @@ function base16-railscasts -d "Railscasts"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param d4cfc9
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=3a4055

--- a/functions/base16-rebecca.fish
+++ b/functions/base16-rebecca.fish
@@ -111,7 +111,7 @@ function base16-rebecca -d "Rebecca"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param a0a0c5
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=383a62

--- a/functions/base16-rose-pine-dawn.fish
+++ b/functions/base16-rose-pine-dawn.fish
@@ -111,7 +111,7 @@ function base16-rose-pine-dawn -d "Rosé Pine Dawn"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 6e6a86
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=f2e9de

--- a/functions/base16-rose-pine-moon.fish
+++ b/functions/base16-rose-pine-moon.fish
@@ -111,7 +111,7 @@ function base16-rose-pine-moon -d "Rosé Pine Moon"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 817c9c
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=393552

--- a/functions/base16-rose-pine.fish
+++ b/functions/base16-rose-pine.fish
@@ -111,7 +111,7 @@ function base16-rose-pine -d "Rosé Pine"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 6e6a86
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=26233a

--- a/functions/base16-sagelight.fish
+++ b/functions/base16-sagelight.fish
@@ -111,7 +111,7 @@ function base16-sagelight -d "Sagelight"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 585858
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d8d8d8

--- a/functions/base16-sakura.fish
+++ b/functions/base16-sakura.fish
@@ -111,7 +111,7 @@ function base16-sakura -d "Sakura"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 665055
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=e0ccd1

--- a/functions/base16-sandcastle.fish
+++ b/functions/base16-sandcastle.fish
@@ -111,7 +111,7 @@ function base16-sandcastle -d "Sandcastle"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 928374
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=3e4451

--- a/functions/base16-seti.fish
+++ b/functions/base16-seti.fish
@@ -111,7 +111,7 @@ function base16-seti -d "Seti UI"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 43a5d5
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=3B758C

--- a/functions/base16-shades-of-purple.fish
+++ b/functions/base16-shades-of-purple.fish
@@ -111,7 +111,7 @@ function base16-shades-of-purple -d "Shades of Purple"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 6871ff
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=f1d000

--- a/functions/base16-shapeshifter.fish
+++ b/functions/base16-shapeshifter.fish
@@ -111,7 +111,7 @@ function base16-shapeshifter -d "Shapeshifter"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 343434
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=ababab

--- a/functions/base16-silk-dark.fish
+++ b/functions/base16-silk-dark.fish
@@ -111,7 +111,7 @@ function base16-silk-dark -d "Silk Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 9DC8CD
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=2A5054

--- a/functions/base16-silk-light.fish
+++ b/functions/base16-silk-light.fish
@@ -111,7 +111,7 @@ function base16-silk-light -d "Silk Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 4B5B5F
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=90B7B6

--- a/functions/base16-snazzy.fish
+++ b/functions/base16-snazzy.fish
@@ -111,7 +111,7 @@ function base16-snazzy -d "Snazzy"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param a5a5a9
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=43454f

--- a/functions/base16-solarflare-light.fish
+++ b/functions/base16-solarflare-light.fish
@@ -111,7 +111,7 @@ function base16-solarflare-light -d "Solar Flare Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 667581
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=A6AFB8

--- a/functions/base16-solarflare.fish
+++ b/functions/base16-solarflare.fish
@@ -111,7 +111,7 @@ function base16-solarflare -d "Solar Flare"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 85939E
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=586875

--- a/functions/base16-solarized-dark.fish
+++ b/functions/base16-solarized-dark.fish
@@ -111,7 +111,7 @@ function base16-solarized-dark -d "Solarized Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 839496
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=586e75

--- a/functions/base16-solarized-light.fish
+++ b/functions/base16-solarized-light.fish
@@ -111,7 +111,7 @@ function base16-solarized-light -d "Solarized Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 657b83
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=93a1a1

--- a/functions/base16-spacemacs.fish
+++ b/functions/base16-spacemacs.fish
@@ -111,7 +111,7 @@ function base16-spacemacs -d "Spacemacs"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b8b8b8
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=444155

--- a/functions/base16-summercamp.fish
+++ b/functions/base16-summercamp.fish
@@ -111,7 +111,7 @@ function base16-summercamp -d "summercamp"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 5f5b45
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=3a3527

--- a/functions/base16-summerfruit-dark.fish
+++ b/functions/base16-summerfruit-dark.fish
@@ -111,7 +111,7 @@ function base16-summerfruit-dark -d "Summerfruit Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param B0B0B0
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=303030

--- a/functions/base16-summerfruit-light.fish
+++ b/functions/base16-summerfruit-light.fish
@@ -111,7 +111,7 @@ function base16-summerfruit-light -d "Summerfruit Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 000000
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=D0D0D0

--- a/functions/base16-synth-midnight-dark.fish
+++ b/functions/base16-synth-midnight-dark.fish
@@ -111,7 +111,7 @@ function base16-synth-midnight-dark -d "Synth Midnight Terminal Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param a3a5a6
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=28292a

--- a/functions/base16-synth-midnight-light.fish
+++ b/functions/base16-synth-midnight-light.fish
@@ -111,7 +111,7 @@ function base16-synth-midnight-light -d "Synth Midnight Terminal Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 474849
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=c1c3c4

--- a/functions/base16-tango.fish
+++ b/functions/base16-tango.fish
@@ -111,7 +111,7 @@ function base16-tango -d "Tango"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 729fcf
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=fce94f

--- a/functions/base16-tender.fish
+++ b/functions/base16-tender.fish
@@ -111,7 +111,7 @@ function base16-tender -d "tender"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b8b8b8
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=484848

--- a/functions/base16-tomorrow-night-eighties.fish
+++ b/functions/base16-tomorrow-night-eighties.fish
@@ -111,7 +111,7 @@ function base16-tomorrow-night-eighties -d "Tomorrow Night"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b4b7b4
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=515151

--- a/functions/base16-tomorrow-night.fish
+++ b/functions/base16-tomorrow-night.fish
@@ -111,7 +111,7 @@ function base16-tomorrow-night -d "Tomorrow Night"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b4b7b4
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=373b41

--- a/functions/base16-tomorrow.fish
+++ b/functions/base16-tomorrow.fish
@@ -111,7 +111,7 @@ function base16-tomorrow -d "Tomorrow"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 969896
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d6d6d6

--- a/functions/base16-tube.fish
+++ b/functions/base16-tube.fish
@@ -111,7 +111,7 @@ function base16-tube -d "London Tube"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 959ca1
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=5a5758

--- a/functions/base16-twilight.fish
+++ b/functions/base16-twilight.fish
@@ -111,7 +111,7 @@ function base16-twilight -d "Twilight"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 838184
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=464b50

--- a/functions/base16-unikitty-dark.fish
+++ b/functions/base16-unikitty-dark.fish
@@ -111,7 +111,7 @@ function base16-unikitty-dark -d "Unikitty Dark"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 9f9da2
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=666369

--- a/functions/base16-unikitty-light.fish
+++ b/functions/base16-unikitty-light.fish
@@ -111,7 +111,7 @@ function base16-unikitty-light -d "Unikitty Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 89878b
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=c4c3c5

--- a/functions/base16-vulcan.fish
+++ b/functions/base16-vulcan.fish
@@ -111,7 +111,7 @@ function base16-vulcan -d "vulcan"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 6b6977
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=003552

--- a/functions/base16-windows-10-light.fish
+++ b/functions/base16-windows-10-light.fish
@@ -111,7 +111,7 @@ function base16-windows-10-light -d "Windows 10 Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param ababab
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d9d9d9

--- a/functions/base16-windows-10.fish
+++ b/functions/base16-windows-10.fish
@@ -111,7 +111,7 @@ function base16-windows-10 -d "Windows 10"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b9b9b9
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=535353

--- a/functions/base16-windows-95-light.fish
+++ b/functions/base16-windows-95-light.fish
@@ -111,7 +111,7 @@ function base16-windows-95-light -d "Windows 95 Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 7e7e7e
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=c4c4c4

--- a/functions/base16-windows-95.fish
+++ b/functions/base16-windows-95.fish
@@ -111,7 +111,7 @@ function base16-windows-95 -d "Windows 95"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 7e7e7e
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=383838

--- a/functions/base16-windows-highcontrast-light.fish
+++ b/functions/base16-windows-highcontrast-light.fish
@@ -111,7 +111,7 @@ function base16-windows-highcontrast-light -d "Windows High Contrast Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 7e7e7e
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d4d4d4

--- a/functions/base16-windows-highcontrast.fish
+++ b/functions/base16-windows-highcontrast.fish
@@ -111,7 +111,7 @@ function base16-windows-highcontrast -d "Windows High Contrast"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param a2a2a2
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=383838

--- a/functions/base16-windows-nt-light.fish
+++ b/functions/base16-windows-nt-light.fish
@@ -111,7 +111,7 @@ function base16-windows-nt-light -d "Windows NT Light"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param a0a0a0
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=d5d5d5

--- a/functions/base16-windows-nt.fish
+++ b/functions/base16-windows-nt.fish
@@ -111,7 +111,7 @@ function base16-windows-nt -d "Windows NT"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param a1a1a1
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=555555

--- a/functions/base16-woodland.fish
+++ b/functions/base16-woodland.fish
@@ -111,7 +111,7 @@ function base16-woodland -d "Woodland"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param b4a490
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=48413a

--- a/functions/base16-xcode-dusk.fish
+++ b/functions/base16-xcode-dusk.fish
@@ -111,7 +111,7 @@ function base16-xcode-dusk -d "XCode Dusk"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 7E8086
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=53555D

--- a/functions/base16-zenburn.fish
+++ b/functions/base16-zenburn.fish
@@ -111,7 +111,7 @@ function base16-zenburn -d "Zenburn"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param 808080
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background=606060

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -111,7 +111,7 @@ function base16-{{scheme-slug}} -d "{{scheme-name}}"
   set -U fish_color_match --background=brblue
   set -U fish_color_normal normal
   set -U fish_color_operator blue #green
-  set -U fish_color_param {{base04-hex}}
+  set -U fish_color_param white
   set -U fish_color_quote yellow #brblack
   set -U fish_color_redirection cyan
   set -U fish_color_search_match bryellow --background={{base02-hex}}


### PR DESCRIPTION
As per the [base16 specification](https://github.com/chriskempson/base16/blob/main/styling.md), base04 is a darker foreground color, which for some color schemes is *quite* dark, making the text hard to read, and ugly. Therefore white (base05) makes way more sense to use, and is used in most other places.