### PR TITLE
use quiet string matching

### DIFF
--- a/functions/base16-3024.fish
+++ b/functions/base16-3024.fish
@@ -34,12 +34,12 @@ function base16-3024 -d "3024"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-3024 -d "3024"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-apathy.fish
+++ b/functions/base16-apathy.fish
@@ -34,12 +34,12 @@ function base16-apathy -d "Apathy"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-apathy -d "Apathy"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-apprentice.fish
+++ b/functions/base16-apprentice.fish
@@ -34,12 +34,12 @@ function base16-apprentice -d "Apprentice"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-apprentice -d "Apprentice"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-ashes.fish
+++ b/functions/base16-ashes.fish
@@ -34,12 +34,12 @@ function base16-ashes -d "Ashes"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-ashes -d "Ashes"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-cave-light.fish
+++ b/functions/base16-atelier-cave-light.fish
@@ -34,12 +34,12 @@ function base16-atelier-cave-light -d "Atelier Cave Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-cave-light -d "Atelier Cave Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-cave.fish
+++ b/functions/base16-atelier-cave.fish
@@ -34,12 +34,12 @@ function base16-atelier-cave -d "Atelier Cave"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-cave -d "Atelier Cave"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-dune-light.fish
+++ b/functions/base16-atelier-dune-light.fish
@@ -34,12 +34,12 @@ function base16-atelier-dune-light -d "Atelier Dune Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-dune-light -d "Atelier Dune Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-dune.fish
+++ b/functions/base16-atelier-dune.fish
@@ -34,12 +34,12 @@ function base16-atelier-dune -d "Atelier Dune"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-dune -d "Atelier Dune"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-estuary-light.fish
+++ b/functions/base16-atelier-estuary-light.fish
@@ -34,12 +34,12 @@ function base16-atelier-estuary-light -d "Atelier Estuary Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-estuary-light -d "Atelier Estuary Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-estuary.fish
+++ b/functions/base16-atelier-estuary.fish
@@ -34,12 +34,12 @@ function base16-atelier-estuary -d "Atelier Estuary"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-estuary -d "Atelier Estuary"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-forest-light.fish
+++ b/functions/base16-atelier-forest-light.fish
@@ -34,12 +34,12 @@ function base16-atelier-forest-light -d "Atelier Forest Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-forest-light -d "Atelier Forest Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-forest.fish
+++ b/functions/base16-atelier-forest.fish
@@ -34,12 +34,12 @@ function base16-atelier-forest -d "Atelier Forest"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-forest -d "Atelier Forest"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-heath-light.fish
+++ b/functions/base16-atelier-heath-light.fish
@@ -34,12 +34,12 @@ function base16-atelier-heath-light -d "Atelier Heath Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-heath-light -d "Atelier Heath Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-heath.fish
+++ b/functions/base16-atelier-heath.fish
@@ -34,12 +34,12 @@ function base16-atelier-heath -d "Atelier Heath"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-heath -d "Atelier Heath"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-lakeside-light.fish
+++ b/functions/base16-atelier-lakeside-light.fish
@@ -34,12 +34,12 @@ function base16-atelier-lakeside-light -d "Atelier Lakeside Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-lakeside-light -d "Atelier Lakeside Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-lakeside.fish
+++ b/functions/base16-atelier-lakeside.fish
@@ -34,12 +34,12 @@ function base16-atelier-lakeside -d "Atelier Lakeside"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-lakeside -d "Atelier Lakeside"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-plateau-light.fish
+++ b/functions/base16-atelier-plateau-light.fish
@@ -34,12 +34,12 @@ function base16-atelier-plateau-light -d "Atelier Plateau Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-plateau-light -d "Atelier Plateau Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-plateau.fish
+++ b/functions/base16-atelier-plateau.fish
@@ -34,12 +34,12 @@ function base16-atelier-plateau -d "Atelier Plateau"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-plateau -d "Atelier Plateau"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-savanna-light.fish
+++ b/functions/base16-atelier-savanna-light.fish
@@ -34,12 +34,12 @@ function base16-atelier-savanna-light -d "Atelier Savanna Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-savanna-light -d "Atelier Savanna Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-savanna.fish
+++ b/functions/base16-atelier-savanna.fish
@@ -34,12 +34,12 @@ function base16-atelier-savanna -d "Atelier Savanna"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-savanna -d "Atelier Savanna"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-seaside-light.fish
+++ b/functions/base16-atelier-seaside-light.fish
@@ -34,12 +34,12 @@ function base16-atelier-seaside-light -d "Atelier Seaside Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-seaside-light -d "Atelier Seaside Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-seaside.fish
+++ b/functions/base16-atelier-seaside.fish
@@ -34,12 +34,12 @@ function base16-atelier-seaside -d "Atelier Seaside"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-seaside -d "Atelier Seaside"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-sulphurpool-light.fish
+++ b/functions/base16-atelier-sulphurpool-light.fish
@@ -34,12 +34,12 @@ function base16-atelier-sulphurpool-light -d "Atelier Sulphurpool Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-sulphurpool-light -d "Atelier Sulphurpool Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atelier-sulphurpool.fish
+++ b/functions/base16-atelier-sulphurpool.fish
@@ -34,12 +34,12 @@ function base16-atelier-sulphurpool -d "Atelier Sulphurpool"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atelier-sulphurpool -d "Atelier Sulphurpool"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-atlas.fish
+++ b/functions/base16-atlas.fish
@@ -34,12 +34,12 @@ function base16-atlas -d "Atlas"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-atlas -d "Atlas"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-bespin.fish
+++ b/functions/base16-bespin.fish
@@ -34,12 +34,12 @@ function base16-bespin -d "Bespin"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-bespin -d "Bespin"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-black-metal-bathory.fish
+++ b/functions/base16-black-metal-bathory.fish
@@ -34,12 +34,12 @@ function base16-black-metal-bathory -d "Black Metal (Bathory)"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-black-metal-bathory -d "Black Metal (Bathory)"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-black-metal-burzum.fish
+++ b/functions/base16-black-metal-burzum.fish
@@ -34,12 +34,12 @@ function base16-black-metal-burzum -d "Black Metal (Burzum)"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-black-metal-burzum -d "Black Metal (Burzum)"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-black-metal-dark-funeral.fish
+++ b/functions/base16-black-metal-dark-funeral.fish
@@ -34,12 +34,12 @@ function base16-black-metal-dark-funeral -d "Black Metal (Dark Funeral)"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-black-metal-dark-funeral -d "Black Metal (Dark Funeral)"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-black-metal-gorgoroth.fish
+++ b/functions/base16-black-metal-gorgoroth.fish
@@ -34,12 +34,12 @@ function base16-black-metal-gorgoroth -d "Black Metal (Gorgoroth)"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-black-metal-gorgoroth -d "Black Metal (Gorgoroth)"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-black-metal-immortal.fish
+++ b/functions/base16-black-metal-immortal.fish
@@ -34,12 +34,12 @@ function base16-black-metal-immortal -d "Black Metal (Immortal)"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-black-metal-immortal -d "Black Metal (Immortal)"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-black-metal-khold.fish
+++ b/functions/base16-black-metal-khold.fish
@@ -34,12 +34,12 @@ function base16-black-metal-khold -d "Black Metal (Khold)"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-black-metal-khold -d "Black Metal (Khold)"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-black-metal-marduk.fish
+++ b/functions/base16-black-metal-marduk.fish
@@ -34,12 +34,12 @@ function base16-black-metal-marduk -d "Black Metal (Marduk)"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-black-metal-marduk -d "Black Metal (Marduk)"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-black-metal-mayhem.fish
+++ b/functions/base16-black-metal-mayhem.fish
@@ -34,12 +34,12 @@ function base16-black-metal-mayhem -d "Black Metal (Mayhem)"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-black-metal-mayhem -d "Black Metal (Mayhem)"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-black-metal-nile.fish
+++ b/functions/base16-black-metal-nile.fish
@@ -34,12 +34,12 @@ function base16-black-metal-nile -d "Black Metal (Nile)"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-black-metal-nile -d "Black Metal (Nile)"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-black-metal-venom.fish
+++ b/functions/base16-black-metal-venom.fish
@@ -34,12 +34,12 @@ function base16-black-metal-venom -d "Black Metal (Venom)"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-black-metal-venom -d "Black Metal (Venom)"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-black-metal.fish
+++ b/functions/base16-black-metal.fish
@@ -34,12 +34,12 @@ function base16-black-metal -d "Black Metal"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-black-metal -d "Black Metal"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-brewer.fish
+++ b/functions/base16-brewer.fish
@@ -34,12 +34,12 @@ function base16-brewer -d "Brewer"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-brewer -d "Brewer"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-bright.fish
+++ b/functions/base16-bright.fish
@@ -34,12 +34,12 @@ function base16-bright -d "Bright"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-bright -d "Bright"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-brogrammer.fish
+++ b/functions/base16-brogrammer.fish
@@ -34,12 +34,12 @@ function base16-brogrammer -d "Brogrammer"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-brogrammer -d "Brogrammer"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-brushtrees-dark.fish
+++ b/functions/base16-brushtrees-dark.fish
@@ -34,12 +34,12 @@ function base16-brushtrees-dark -d "Brush Trees Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-brushtrees-dark -d "Brush Trees Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-brushtrees.fish
+++ b/functions/base16-brushtrees.fish
@@ -34,12 +34,12 @@ function base16-brushtrees -d "Brush Trees"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-brushtrees -d "Brush Trees"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-chalk.fish
+++ b/functions/base16-chalk.fish
@@ -34,12 +34,12 @@ function base16-chalk -d "Chalk"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-chalk -d "Chalk"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-circus.fish
+++ b/functions/base16-circus.fish
@@ -34,12 +34,12 @@ function base16-circus -d "Circus"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-circus -d "Circus"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-classic-dark.fish
+++ b/functions/base16-classic-dark.fish
@@ -34,12 +34,12 @@ function base16-classic-dark -d "Classic Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-classic-dark -d "Classic Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-classic-light.fish
+++ b/functions/base16-classic-light.fish
@@ -34,12 +34,12 @@ function base16-classic-light -d "Classic Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-classic-light -d "Classic Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-codeschool.fish
+++ b/functions/base16-codeschool.fish
@@ -34,12 +34,12 @@ function base16-codeschool -d "Codeschool"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-codeschool -d "Codeschool"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-colors.fish
+++ b/functions/base16-colors.fish
@@ -34,12 +34,12 @@ function base16-colors -d "Colors"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-colors -d "Colors"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-cupcake.fish
+++ b/functions/base16-cupcake.fish
@@ -34,12 +34,12 @@ function base16-cupcake -d "Cupcake"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-cupcake -d "Cupcake"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-cupertino.fish
+++ b/functions/base16-cupertino.fish
@@ -34,12 +34,12 @@ function base16-cupertino -d "Cupertino"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-cupertino -d "Cupertino"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-danqing.fish
+++ b/functions/base16-danqing.fish
@@ -34,12 +34,12 @@ function base16-danqing -d "DanQing"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-danqing -d "DanQing"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-darcula.fish
+++ b/functions/base16-darcula.fish
@@ -34,12 +34,12 @@ function base16-darcula -d "Darcula"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-darcula -d "Darcula"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-darkmoss.fish
+++ b/functions/base16-darkmoss.fish
@@ -34,12 +34,12 @@ function base16-darkmoss -d "darkmoss"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-darkmoss -d "darkmoss"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-darktooth.fish
+++ b/functions/base16-darktooth.fish
@@ -34,12 +34,12 @@ function base16-darktooth -d "Darktooth"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-darktooth -d "Darktooth"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-darkviolet.fish
+++ b/functions/base16-darkviolet.fish
@@ -34,12 +34,12 @@ function base16-darkviolet -d "Dark Violet"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-darkviolet -d "Dark Violet"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-decaf.fish
+++ b/functions/base16-decaf.fish
@@ -34,12 +34,12 @@ function base16-decaf -d "Decaf"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-decaf -d "Decaf"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-default-dark.fish
+++ b/functions/base16-default-dark.fish
@@ -34,12 +34,12 @@ function base16-default-dark -d "Default Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-default-dark -d "Default Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-default-light.fish
+++ b/functions/base16-default-light.fish
@@ -34,12 +34,12 @@ function base16-default-light -d "Default Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-default-light -d "Default Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-dirtysea.fish
+++ b/functions/base16-dirtysea.fish
@@ -34,12 +34,12 @@ function base16-dirtysea -d "dirtysea"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-dirtysea -d "dirtysea"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-dracula.fish
+++ b/functions/base16-dracula.fish
@@ -34,12 +34,12 @@ function base16-dracula -d "Dracula"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-dracula -d "Dracula"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-edge-dark.fish
+++ b/functions/base16-edge-dark.fish
@@ -34,12 +34,12 @@ function base16-edge-dark -d "Edge Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-edge-dark -d "Edge Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-edge-light.fish
+++ b/functions/base16-edge-light.fish
@@ -34,12 +34,12 @@ function base16-edge-light -d "Edge Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-edge-light -d "Edge Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-eighties.fish
+++ b/functions/base16-eighties.fish
@@ -34,12 +34,12 @@ function base16-eighties -d "Eighties"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-eighties -d "Eighties"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-embers.fish
+++ b/functions/base16-embers.fish
@@ -34,12 +34,12 @@ function base16-embers -d "Embers"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-embers -d "Embers"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-equilibrium-dark.fish
+++ b/functions/base16-equilibrium-dark.fish
@@ -34,12 +34,12 @@ function base16-equilibrium-dark -d "Equilibrium Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-equilibrium-dark -d "Equilibrium Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-equilibrium-gray-dark.fish
+++ b/functions/base16-equilibrium-gray-dark.fish
@@ -34,12 +34,12 @@ function base16-equilibrium-gray-dark -d "Equilibrium Gray Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-equilibrium-gray-dark -d "Equilibrium Gray Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-equilibrium-gray-light.fish
+++ b/functions/base16-equilibrium-gray-light.fish
@@ -34,12 +34,12 @@ function base16-equilibrium-gray-light -d "Equilibrium Gray Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-equilibrium-gray-light -d "Equilibrium Gray Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-equilibrium-light.fish
+++ b/functions/base16-equilibrium-light.fish
@@ -34,12 +34,12 @@ function base16-equilibrium-light -d "Equilibrium Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-equilibrium-light -d "Equilibrium Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-espresso.fish
+++ b/functions/base16-espresso.fish
@@ -34,12 +34,12 @@ function base16-espresso -d "Espresso"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-espresso -d "Espresso"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-eva-dim.fish
+++ b/functions/base16-eva-dim.fish
@@ -34,12 +34,12 @@ function base16-eva-dim -d "Eva Dim"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-eva-dim -d "Eva Dim"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-eva.fish
+++ b/functions/base16-eva.fish
@@ -34,12 +34,12 @@ function base16-eva -d "Eva"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-eva -d "Eva"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-flat.fish
+++ b/functions/base16-flat.fish
@@ -34,12 +34,12 @@ function base16-flat -d "Flat"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-flat -d "Flat"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-framer.fish
+++ b/functions/base16-framer.fish
@@ -34,12 +34,12 @@ function base16-framer -d "Framer"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-framer -d "Framer"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-fruit-soda.fish
+++ b/functions/base16-fruit-soda.fish
@@ -34,12 +34,12 @@ function base16-fruit-soda -d "Fruit Soda"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-fruit-soda -d "Fruit Soda"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-gigavolt.fish
+++ b/functions/base16-gigavolt.fish
@@ -34,12 +34,12 @@ function base16-gigavolt -d "Gigavolt"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-gigavolt -d "Gigavolt"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-github.fish
+++ b/functions/base16-github.fish
@@ -34,12 +34,12 @@ function base16-github -d "Github"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-github -d "Github"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-google-dark.fish
+++ b/functions/base16-google-dark.fish
@@ -34,12 +34,12 @@ function base16-google-dark -d "Google Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-google-dark -d "Google Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-google-light.fish
+++ b/functions/base16-google-light.fish
@@ -34,12 +34,12 @@ function base16-google-light -d "Google Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-google-light -d "Google Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-grayscale-dark.fish
+++ b/functions/base16-grayscale-dark.fish
@@ -34,12 +34,12 @@ function base16-grayscale-dark -d "Grayscale Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-grayscale-dark -d "Grayscale Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-grayscale-light.fish
+++ b/functions/base16-grayscale-light.fish
@@ -34,12 +34,12 @@ function base16-grayscale-light -d "Grayscale Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-grayscale-light -d "Grayscale Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-greenscreen.fish
+++ b/functions/base16-greenscreen.fish
@@ -34,12 +34,12 @@ function base16-greenscreen -d "Green Screen"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-greenscreen -d "Green Screen"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-gruvbox-dark-hard.fish
+++ b/functions/base16-gruvbox-dark-hard.fish
@@ -34,12 +34,12 @@ function base16-gruvbox-dark-hard -d "Gruvbox dark, hard"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-gruvbox-dark-hard -d "Gruvbox dark, hard"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-gruvbox-dark-medium.fish
+++ b/functions/base16-gruvbox-dark-medium.fish
@@ -34,12 +34,12 @@ function base16-gruvbox-dark-medium -d "Gruvbox dark, medium"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-gruvbox-dark-medium -d "Gruvbox dark, medium"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-gruvbox-dark-pale.fish
+++ b/functions/base16-gruvbox-dark-pale.fish
@@ -34,12 +34,12 @@ function base16-gruvbox-dark-pale -d "Gruvbox dark, pale"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-gruvbox-dark-pale -d "Gruvbox dark, pale"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-gruvbox-dark-soft.fish
+++ b/functions/base16-gruvbox-dark-soft.fish
@@ -34,12 +34,12 @@ function base16-gruvbox-dark-soft -d "Gruvbox dark, soft"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-gruvbox-dark-soft -d "Gruvbox dark, soft"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-gruvbox-light-hard.fish
+++ b/functions/base16-gruvbox-light-hard.fish
@@ -34,12 +34,12 @@ function base16-gruvbox-light-hard -d "Gruvbox light, hard"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-gruvbox-light-hard -d "Gruvbox light, hard"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-gruvbox-light-medium.fish
+++ b/functions/base16-gruvbox-light-medium.fish
@@ -34,12 +34,12 @@ function base16-gruvbox-light-medium -d "Gruvbox light, medium"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-gruvbox-light-medium -d "Gruvbox light, medium"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-gruvbox-light-soft.fish
+++ b/functions/base16-gruvbox-light-soft.fish
@@ -34,12 +34,12 @@ function base16-gruvbox-light-soft -d "Gruvbox light, soft"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-gruvbox-light-soft -d "Gruvbox light, soft"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-hardcore.fish
+++ b/functions/base16-hardcore.fish
@@ -34,12 +34,12 @@ function base16-hardcore -d "Hardcore"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-hardcore -d "Hardcore"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-harmonic-dark.fish
+++ b/functions/base16-harmonic-dark.fish
@@ -34,12 +34,12 @@ function base16-harmonic-dark -d "Harmonic16 Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-harmonic-dark -d "Harmonic16 Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-harmonic-light.fish
+++ b/functions/base16-harmonic-light.fish
@@ -34,12 +34,12 @@ function base16-harmonic-light -d "Harmonic16 Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-harmonic-light -d "Harmonic16 Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-heetch-light.fish
+++ b/functions/base16-heetch-light.fish
@@ -34,12 +34,12 @@ function base16-heetch-light -d "Heetch Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-heetch-light -d "Heetch Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-heetch.fish
+++ b/functions/base16-heetch.fish
@@ -34,12 +34,12 @@ function base16-heetch -d "Heetch Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-heetch -d "Heetch Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-helios.fish
+++ b/functions/base16-helios.fish
@@ -34,12 +34,12 @@ function base16-helios -d "Helios"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-helios -d "Helios"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-hopscotch.fish
+++ b/functions/base16-hopscotch.fish
@@ -34,12 +34,12 @@ function base16-hopscotch -d "Hopscotch"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-hopscotch -d "Hopscotch"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-horizon-dark.fish
+++ b/functions/base16-horizon-dark.fish
@@ -34,12 +34,12 @@ function base16-horizon-dark -d "Horizon Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-horizon-dark -d "Horizon Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-horizon-light.fish
+++ b/functions/base16-horizon-light.fish
@@ -34,12 +34,12 @@ function base16-horizon-light -d "Horizon Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-horizon-light -d "Horizon Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-horizon-terminal-dark.fish
+++ b/functions/base16-horizon-terminal-dark.fish
@@ -34,12 +34,12 @@ function base16-horizon-terminal-dark -d "Horizon Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-horizon-terminal-dark -d "Horizon Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-horizon-terminal-light.fish
+++ b/functions/base16-horizon-terminal-light.fish
@@ -34,12 +34,12 @@ function base16-horizon-terminal-light -d "Horizon Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-horizon-terminal-light -d "Horizon Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-humanoid-dark.fish
+++ b/functions/base16-humanoid-dark.fish
@@ -34,12 +34,12 @@ function base16-humanoid-dark -d "Humanoid dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-humanoid-dark -d "Humanoid dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-humanoid-light.fish
+++ b/functions/base16-humanoid-light.fish
@@ -34,12 +34,12 @@ function base16-humanoid-light -d "Humanoid light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-humanoid-light -d "Humanoid light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-ia-dark.fish
+++ b/functions/base16-ia-dark.fish
@@ -34,12 +34,12 @@ function base16-ia-dark -d "iA Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-ia-dark -d "iA Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-ia-light.fish
+++ b/functions/base16-ia-light.fish
@@ -34,12 +34,12 @@ function base16-ia-light -d "iA Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-ia-light -d "iA Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-icy.fish
+++ b/functions/base16-icy.fish
@@ -34,12 +34,12 @@ function base16-icy -d "Icy Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-icy -d "Icy Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-irblack.fish
+++ b/functions/base16-irblack.fish
@@ -34,12 +34,12 @@ function base16-irblack -d "IR Black"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-irblack -d "IR Black"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-isotope.fish
+++ b/functions/base16-isotope.fish
@@ -34,12 +34,12 @@ function base16-isotope -d "Isotope"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-isotope -d "Isotope"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-kimber.fish
+++ b/functions/base16-kimber.fish
@@ -34,12 +34,12 @@ function base16-kimber -d "Kimber"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-kimber -d "Kimber"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-macintosh.fish
+++ b/functions/base16-macintosh.fish
@@ -34,12 +34,12 @@ function base16-macintosh -d "Macintosh"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-macintosh -d "Macintosh"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-marrakesh.fish
+++ b/functions/base16-marrakesh.fish
@@ -34,12 +34,12 @@ function base16-marrakesh -d "Marrakesh"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-marrakesh -d "Marrakesh"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-materia.fish
+++ b/functions/base16-materia.fish
@@ -34,12 +34,12 @@ function base16-materia -d "Materia"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-materia -d "Materia"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-material-darker.fish
+++ b/functions/base16-material-darker.fish
@@ -34,12 +34,12 @@ function base16-material-darker -d "Material Darker"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-material-darker -d "Material Darker"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-material-lighter.fish
+++ b/functions/base16-material-lighter.fish
@@ -34,12 +34,12 @@ function base16-material-lighter -d "Material Lighter"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-material-lighter -d "Material Lighter"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-material-palenight.fish
+++ b/functions/base16-material-palenight.fish
@@ -34,12 +34,12 @@ function base16-material-palenight -d "Material Palenight"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-material-palenight -d "Material Palenight"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-material-vivid.fish
+++ b/functions/base16-material-vivid.fish
@@ -34,12 +34,12 @@ function base16-material-vivid -d "Material Vivid"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-material-vivid -d "Material Vivid"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-material.fish
+++ b/functions/base16-material.fish
@@ -34,12 +34,12 @@ function base16-material -d "Material"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-material -d "Material"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-mellow-purple.fish
+++ b/functions/base16-mellow-purple.fish
@@ -34,12 +34,12 @@ function base16-mellow-purple -d "Mellow Purple"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-mellow-purple -d "Mellow Purple"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-mexico-light.fish
+++ b/functions/base16-mexico-light.fish
@@ -34,12 +34,12 @@ function base16-mexico-light -d "Mexico Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-mexico-light -d "Mexico Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-mocha.fish
+++ b/functions/base16-mocha.fish
@@ -34,12 +34,12 @@ function base16-mocha -d "Mocha"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-mocha -d "Mocha"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-monokai.fish
+++ b/functions/base16-monokai.fish
@@ -34,12 +34,12 @@ function base16-monokai -d "Monokai"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-monokai -d "Monokai"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-nebula.fish
+++ b/functions/base16-nebula.fish
@@ -34,12 +34,12 @@ function base16-nebula -d "Nebula"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-nebula -d "Nebula"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-nord.fish
+++ b/functions/base16-nord.fish
@@ -34,12 +34,12 @@ function base16-nord -d "Nord"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-nord -d "Nord"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-nova.fish
+++ b/functions/base16-nova.fish
@@ -34,12 +34,12 @@ function base16-nova -d "Nova"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-nova -d "Nova"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-ocean.fish
+++ b/functions/base16-ocean.fish
@@ -34,12 +34,12 @@ function base16-ocean -d "Ocean"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-ocean -d "Ocean"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-oceanicnext.fish
+++ b/functions/base16-oceanicnext.fish
@@ -34,12 +34,12 @@ function base16-oceanicnext -d "OceanicNext"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-oceanicnext -d "OceanicNext"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-one-light.fish
+++ b/functions/base16-one-light.fish
@@ -34,12 +34,12 @@ function base16-one-light -d "One Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-one-light -d "One Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-onedark.fish
+++ b/functions/base16-onedark.fish
@@ -34,12 +34,12 @@ function base16-onedark -d "OneDark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-onedark -d "OneDark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-outrun-dark.fish
+++ b/functions/base16-outrun-dark.fish
@@ -34,12 +34,12 @@ function base16-outrun-dark -d "Outrun Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-outrun-dark -d "Outrun Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-papercolor-dark.fish
+++ b/functions/base16-papercolor-dark.fish
@@ -34,12 +34,12 @@ function base16-papercolor-dark -d "PaperColor Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-papercolor-dark -d "PaperColor Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-papercolor-light.fish
+++ b/functions/base16-papercolor-light.fish
@@ -34,12 +34,12 @@ function base16-papercolor-light -d "PaperColor Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-papercolor-light -d "PaperColor Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-paraiso.fish
+++ b/functions/base16-paraiso.fish
@@ -34,12 +34,12 @@ function base16-paraiso -d "Paraiso"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-paraiso -d "Paraiso"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-pasque.fish
+++ b/functions/base16-pasque.fish
@@ -34,12 +34,12 @@ function base16-pasque -d "Pasque"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-pasque -d "Pasque"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-phd.fish
+++ b/functions/base16-phd.fish
@@ -34,12 +34,12 @@ function base16-phd -d "PhD"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-phd -d "PhD"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-pico.fish
+++ b/functions/base16-pico.fish
@@ -34,12 +34,12 @@ function base16-pico -d "Pico"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-pico -d "Pico"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-pinky.fish
+++ b/functions/base16-pinky.fish
@@ -34,12 +34,12 @@ function base16-pinky -d "pinky"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-pinky -d "pinky"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-pop.fish
+++ b/functions/base16-pop.fish
@@ -34,12 +34,12 @@ function base16-pop -d "Pop"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-pop -d "Pop"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-porple.fish
+++ b/functions/base16-porple.fish
@@ -34,12 +34,12 @@ function base16-porple -d "Porple"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-porple -d "Porple"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-qualia.fish
+++ b/functions/base16-qualia.fish
@@ -34,12 +34,12 @@ function base16-qualia -d "Qualia"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-qualia -d "Qualia"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-railscasts.fish
+++ b/functions/base16-railscasts.fish
@@ -34,12 +34,12 @@ function base16-railscasts -d "Railscasts"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-railscasts -d "Railscasts"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-rebecca.fish
+++ b/functions/base16-rebecca.fish
@@ -34,12 +34,12 @@ function base16-rebecca -d "Rebecca"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-rebecca -d "Rebecca"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-rose-pine-dawn.fish
+++ b/functions/base16-rose-pine-dawn.fish
@@ -34,12 +34,12 @@ function base16-rose-pine-dawn -d "Rosé Pine Dawn"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-rose-pine-dawn -d "Rosé Pine Dawn"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-rose-pine-moon.fish
+++ b/functions/base16-rose-pine-moon.fish
@@ -34,12 +34,12 @@ function base16-rose-pine-moon -d "Rosé Pine Moon"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-rose-pine-moon -d "Rosé Pine Moon"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-rose-pine.fish
+++ b/functions/base16-rose-pine.fish
@@ -34,12 +34,12 @@ function base16-rose-pine -d "Rosé Pine"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-rose-pine -d "Rosé Pine"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-sagelight.fish
+++ b/functions/base16-sagelight.fish
@@ -34,12 +34,12 @@ function base16-sagelight -d "Sagelight"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-sagelight -d "Sagelight"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-sakura.fish
+++ b/functions/base16-sakura.fish
@@ -34,12 +34,12 @@ function base16-sakura -d "Sakura"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-sakura -d "Sakura"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-sandcastle.fish
+++ b/functions/base16-sandcastle.fish
@@ -34,12 +34,12 @@ function base16-sandcastle -d "Sandcastle"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-sandcastle -d "Sandcastle"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-seti.fish
+++ b/functions/base16-seti.fish
@@ -34,12 +34,12 @@ function base16-seti -d "Seti UI"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-seti -d "Seti UI"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-shades-of-purple.fish
+++ b/functions/base16-shades-of-purple.fish
@@ -34,12 +34,12 @@ function base16-shades-of-purple -d "Shades of Purple"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-shades-of-purple -d "Shades of Purple"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-shapeshifter.fish
+++ b/functions/base16-shapeshifter.fish
@@ -34,12 +34,12 @@ function base16-shapeshifter -d "Shapeshifter"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-shapeshifter -d "Shapeshifter"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-silk-dark.fish
+++ b/functions/base16-silk-dark.fish
@@ -34,12 +34,12 @@ function base16-silk-dark -d "Silk Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-silk-dark -d "Silk Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-silk-light.fish
+++ b/functions/base16-silk-light.fish
@@ -34,12 +34,12 @@ function base16-silk-light -d "Silk Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-silk-light -d "Silk Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-snazzy.fish
+++ b/functions/base16-snazzy.fish
@@ -34,12 +34,12 @@ function base16-snazzy -d "Snazzy"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-snazzy -d "Snazzy"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-solarflare-light.fish
+++ b/functions/base16-solarflare-light.fish
@@ -34,12 +34,12 @@ function base16-solarflare-light -d "Solar Flare Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-solarflare-light -d "Solar Flare Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-solarflare.fish
+++ b/functions/base16-solarflare.fish
@@ -34,12 +34,12 @@ function base16-solarflare -d "Solar Flare"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-solarflare -d "Solar Flare"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-solarized-dark.fish
+++ b/functions/base16-solarized-dark.fish
@@ -34,12 +34,12 @@ function base16-solarized-dark -d "Solarized Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-solarized-dark -d "Solarized Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-solarized-light.fish
+++ b/functions/base16-solarized-light.fish
@@ -34,12 +34,12 @@ function base16-solarized-light -d "Solarized Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-solarized-light -d "Solarized Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-spacemacs.fish
+++ b/functions/base16-spacemacs.fish
@@ -34,12 +34,12 @@ function base16-spacemacs -d "Spacemacs"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-spacemacs -d "Spacemacs"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-summercamp.fish
+++ b/functions/base16-summercamp.fish
@@ -34,12 +34,12 @@ function base16-summercamp -d "summercamp"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-summercamp -d "summercamp"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-summerfruit-dark.fish
+++ b/functions/base16-summerfruit-dark.fish
@@ -34,12 +34,12 @@ function base16-summerfruit-dark -d "Summerfruit Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-summerfruit-dark -d "Summerfruit Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-summerfruit-light.fish
+++ b/functions/base16-summerfruit-light.fish
@@ -34,12 +34,12 @@ function base16-summerfruit-light -d "Summerfruit Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-summerfruit-light -d "Summerfruit Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-synth-midnight-dark.fish
+++ b/functions/base16-synth-midnight-dark.fish
@@ -34,12 +34,12 @@ function base16-synth-midnight-dark -d "Synth Midnight Terminal Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-synth-midnight-dark -d "Synth Midnight Terminal Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-synth-midnight-light.fish
+++ b/functions/base16-synth-midnight-light.fish
@@ -34,12 +34,12 @@ function base16-synth-midnight-light -d "Synth Midnight Terminal Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-synth-midnight-light -d "Synth Midnight Terminal Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-tango.fish
+++ b/functions/base16-tango.fish
@@ -34,12 +34,12 @@ function base16-tango -d "Tango"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-tango -d "Tango"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-tender.fish
+++ b/functions/base16-tender.fish
@@ -34,12 +34,12 @@ function base16-tender -d "tender"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-tender -d "tender"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-tomorrow-night-eighties.fish
+++ b/functions/base16-tomorrow-night-eighties.fish
@@ -34,12 +34,12 @@ function base16-tomorrow-night-eighties -d "Tomorrow Night"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-tomorrow-night-eighties -d "Tomorrow Night"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-tomorrow-night.fish
+++ b/functions/base16-tomorrow-night.fish
@@ -34,12 +34,12 @@ function base16-tomorrow-night -d "Tomorrow Night"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-tomorrow-night -d "Tomorrow Night"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-tomorrow.fish
+++ b/functions/base16-tomorrow.fish
@@ -34,12 +34,12 @@ function base16-tomorrow -d "Tomorrow"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-tomorrow -d "Tomorrow"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-tube.fish
+++ b/functions/base16-tube.fish
@@ -34,12 +34,12 @@ function base16-tube -d "London Tube"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-tube -d "London Tube"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-twilight.fish
+++ b/functions/base16-twilight.fish
@@ -34,12 +34,12 @@ function base16-twilight -d "Twilight"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-twilight -d "Twilight"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-unikitty-dark.fish
+++ b/functions/base16-unikitty-dark.fish
@@ -34,12 +34,12 @@ function base16-unikitty-dark -d "Unikitty Dark"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-unikitty-dark -d "Unikitty Dark"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-unikitty-light.fish
+++ b/functions/base16-unikitty-light.fish
@@ -34,12 +34,12 @@ function base16-unikitty-light -d "Unikitty Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-unikitty-light -d "Unikitty Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-vulcan.fish
+++ b/functions/base16-vulcan.fish
@@ -34,12 +34,12 @@ function base16-vulcan -d "vulcan"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-vulcan -d "vulcan"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-windows-10-light.fish
+++ b/functions/base16-windows-10-light.fish
@@ -34,12 +34,12 @@ function base16-windows-10-light -d "Windows 10 Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-windows-10-light -d "Windows 10 Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-windows-10.fish
+++ b/functions/base16-windows-10.fish
@@ -34,12 +34,12 @@ function base16-windows-10 -d "Windows 10"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-windows-10 -d "Windows 10"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-windows-95-light.fish
+++ b/functions/base16-windows-95-light.fish
@@ -34,12 +34,12 @@ function base16-windows-95-light -d "Windows 95 Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-windows-95-light -d "Windows 95 Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-windows-95.fish
+++ b/functions/base16-windows-95.fish
@@ -34,12 +34,12 @@ function base16-windows-95 -d "Windows 95"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-windows-95 -d "Windows 95"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-windows-highcontrast-light.fish
+++ b/functions/base16-windows-highcontrast-light.fish
@@ -34,12 +34,12 @@ function base16-windows-highcontrast-light -d "Windows High Contrast Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-windows-highcontrast-light -d "Windows High Contrast Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-windows-highcontrast.fish
+++ b/functions/base16-windows-highcontrast.fish
@@ -34,12 +34,12 @@ function base16-windows-highcontrast -d "Windows High Contrast"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-windows-highcontrast -d "Windows High Contrast"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-windows-nt-light.fish
+++ b/functions/base16-windows-nt-light.fish
@@ -34,12 +34,12 @@ function base16-windows-nt-light -d "Windows NT Light"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-windows-nt-light -d "Windows NT Light"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-windows-nt.fish
+++ b/functions/base16-windows-nt.fish
@@ -34,12 +34,12 @@ function base16-windows-nt -d "Windows NT"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-windows-nt -d "Windows NT"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-woodland.fish
+++ b/functions/base16-woodland.fish
@@ -34,12 +34,12 @@ function base16-woodland -d "Woodland"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-woodland -d "Woodland"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-xcode-dusk.fish
+++ b/functions/base16-xcode-dusk.fish
@@ -34,12 +34,12 @@ function base16-xcode-dusk -d "XCode Dusk"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-xcode-dusk -d "XCode Dusk"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/functions/base16-zenburn.fish
+++ b/functions/base16-zenburn.fish
@@ -34,12 +34,12 @@ function base16-zenburn -d "Zenburn"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-zenburn -d "Zenburn"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -34,12 +34,12 @@ function base16-{{scheme-slug}} -d "{{scheme-name}}"
     function put_template; printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_var; printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $argv; end;
     function put_template_custom; printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $argv; end;
-  else if string match 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
+  else if string match -q 'screen*' $TERM # [ "${TERM%%[-.]*}" = "screen" ]
     # GNU screen (screen, screen-256color, screen-256color-bce)
     function put_template; printf '\033P\033]4;%d;rgb:%s\007\033\\' $argv; end;
     function put_template_var; printf '\033P\033]%d;rgb:%s\007\033\\' $argv; end;
     function put_template_custom; printf '\033P\033]%s%s\007\033\\' $argv; end;
-  else if string match 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
+  else if string match -q 'linux*' $TERM # [ "${TERM%%-*}" = "linux" ]
     function put_template; test $argv[1] -lt 16 && printf "\e]P%x%s" $argv[1] (echo $argv[2] | sed 's/\///g'); end;
     function put_template_var; true; end;
     function put_template_custom; true; end;
@@ -89,7 +89,7 @@ function base16-{{scheme-slug}} -d "{{scheme-name}}"
     put_template_var 10 $colorfg
     if [ "$BASE16_SHELL_SET_BACKGROUND" != false ]
       put_template_var 11 $colorbg
-      if string match 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
+      if string match -q 'rxvt*' $TERM # [ "${TERM%%-*}" = "rxvt" ]
         put_template_var 708 $colorbg # internal border (rxvt)
       end
     end


### PR DESCRIPTION
Fixes #13
use quiet string matching to prevent substring matches from being printed to stdout